### PR TITLE
Set locale correctly on bash

### DIFF
--- a/configs/bash/default.nix
+++ b/configs/bash/default.nix
@@ -1,0 +1,9 @@
+{ config, pkgs, ... }: {
+  programs.bash = {
+    enable = true;
+    initExtra = ''
+      export LC_ALL=en_US.UTF-8
+      export LANG=en_US.UTF-8
+    '';
+  };
+}

--- a/configs/default.nix
+++ b/configs/default.nix
@@ -3,6 +3,7 @@
     ./git
     ./tmux
     ./vim
+    ./bash
     ./fish
     ./gnupg
     ./ssh

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -20,8 +20,8 @@ in
       set TZ Asia/Kolkata
     '' +
     ''
-      set -gx LC_ALL en_IN.UTF-8
-      set -gx LANG en_IN.UTF-8
+      set -gx LC_ALL en_US.UTF-8
+      set -gx LANG en_US.UTF-8
 
       set -U fish_color_autosuggestion      brblack
       set -U fish_color_cancel              -r

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # this is a quick util a good GitHub samaritan wrote to solve for
+    # https://github.com/nix-community/home-manager/issues/1341#issuecomment-1791545015
     mac-app-util = {
       url = "github:hraban/mac-app-util";
     };

--- a/hosts/ckmac/configuration.nix
+++ b/hosts/ckmac/configuration.nix
@@ -22,6 +22,7 @@
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;
 
+  # TODO: generalize the username here
   system.activationScripts.postActivation.text = ''
     chsh -s /run/current-system/sw/bin/fish rounak
   '';


### PR DESCRIPTION
```
bash: warning: setlocale: LC_ALL: cannot change locale (en_IN.UTF-8): No such file or directory
```

This finally helps get rid of the above error. Turns out that `en_US` is the nearest locale that comes pre-installed, although I'd have loved to set the `en_IN` locale.