### PR TITLE
Copy over fish variable exports to bash

### DIFF
--- a/configs/bash/default.nix
+++ b/configs/bash/default.nix
@@ -1,10 +1,26 @@
-{ config, pkgs, ... }: {
+{ config, pkgs, ... }:
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+in
+{
   programs.bash = {
     enable = true;
     initExtra = ''
       export LC_ALL=en_US.UTF-8
       export LANG=en_US.UTF-8
       export PASSWORD_STORE_DIR=/Users/${config.home.username}/.password-store
-    '';
+    '' +
+    (if isDarwin then
+      ''
+        export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
+        export PATH="$PATH:/etc/profiles/per-user/${config.home.username}/bin"
+        export PATH="$PATH:/opt/homebrew/bin"
+        export JAVA_HOME=/usr/libexec/java_home
+        export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
+      ''
+    else
+      ''
+      ''
+    );
   };
 }

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -58,12 +58,12 @@ in
     '' +
     (if isDarwin then
       ''
-                # this is needed, otherwise darwin-rebuild wouldn't be in PATH
-                fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
-                set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
-                set PATH $PATH /opt/homebrew/bin
-                set JAVA_HOME /usr/libexec/java_home
-        	set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
+        # this is needed, otherwise darwin-rebuild wouldn't be in PATH
+        fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
+        set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
+        set PATH $PATH /opt/homebrew/bin
+        set JAVA_HOME /usr/libexec/java_home
+        set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
       ''
     else
       ''


### PR DESCRIPTION
Encountered this when running `./gradlew clean build` and found `yarn` to be failing. Somehow gradle wrapper is still using bash even though fish is set as the default shell. Nevertheless, bash deserves an equal treatment.