### PR TITLE
Migrate node package from nixpkgs to homebrew

### DIFF
--- a/configs/bash/default.nix
+++ b/configs/bash/default.nix
@@ -15,6 +15,7 @@ in
         export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
         export PATH="$PATH:/etc/profiles/per-user/${config.home.username}/bin"
         export PATH="$PATH:/opt/homebrew/bin"
+	export PATH="$PATH:/opt/homebrew/opt/node@18/bin"
         export JAVA_HOME=/usr/libexec/java_home
         export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
       ''

--- a/configs/bash/default.nix
+++ b/configs/bash/default.nix
@@ -12,12 +12,12 @@ in
     '' +
     (if isDarwin then
       ''
-        export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
-        export PATH="$PATH:/etc/profiles/per-user/${config.home.username}/bin"
-        export PATH="$PATH:/opt/homebrew/bin"
-	export PATH="$PATH:/opt/homebrew/opt/node@18/bin"
-        export JAVA_HOME=/usr/libexec/java_home
-        export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
+                export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
+                export PATH="$PATH:/etc/profiles/per-user/${config.home.username}/bin"
+                export PATH="$PATH:/opt/homebrew/bin"
+        	export PATH="$PATH:/opt/homebrew/opt/node@18/bin"
+                export JAVA_HOME=/usr/libexec/java_home
+                export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
       ''
     else
       ''

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -62,6 +62,7 @@ in
         fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
         set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
         set PATH $PATH /opt/homebrew/bin
+	set PATH $PATH /opt/homebrew/opt/node@18/bin
         set JAVA_HOME /usr/libexec/java_home
         set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
       ''

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -58,13 +58,13 @@ in
     '' +
     (if isDarwin then
       ''
-        # this is needed, otherwise darwin-rebuild wouldn't be in PATH
-        fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
-        set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
-        set PATH $PATH /opt/homebrew/bin
-	set PATH $PATH /opt/homebrew/opt/node@18/bin
-        set JAVA_HOME /usr/libexec/java_home
-        set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
+                # this is needed, otherwise darwin-rebuild wouldn't be in PATH
+                fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
+                set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
+                set PATH $PATH /opt/homebrew/bin
+        	set PATH $PATH /opt/homebrew/opt/node@18/bin
+                set JAVA_HOME /usr/libexec/java_home
+                set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
       ''
     else
       ''

--- a/hosts/ckmac/home.nix
+++ b/hosts/ckmac/home.nix
@@ -33,7 +33,6 @@
       kotlin
       shellcheck
       zoom-us
-      nodejs_18
       nixpkgs-fmt
       gradle_7
 

--- a/hosts/ckmac/software.nix
+++ b/hosts/ckmac/software.nix
@@ -43,6 +43,7 @@
       "pulumi/tap/pulumi"
       "skaffold"
       "watch"
+      "node@18"
       "yarn" # the JS package manager, not the hadoop scheduler
       "azure-cli"
       "ollama"


### PR DESCRIPTION
The gradle wrapper (`gradlew`) often expects a system-wide installation of binaries. In a project, we have a gradle task which require `npm`. But since our NixPkgs installation is per-user (home-manager managed), it complains that the binary is not present. This happens despite the PATH variable set rightly.

To mitigate this, we can use brew's way of system-wide installation of node@18.