### PR TITLE
Include activation functions to setup password store

### DIFF
--- a/configs/bash/default.nix
+++ b/configs/bash/default.nix
@@ -8,16 +8,16 @@ in
     initExtra = ''
       export LC_ALL=en_US.UTF-8
       export LANG=en_US.UTF-8
-      export PASSWORD_STORE_DIR=/Users/${config.home.username}/.password-store
     '' +
     (if isDarwin then
       ''
-                export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
-                export PATH="$PATH:/etc/profiles/per-user/${config.home.username}/bin"
-                export PATH="$PATH:/opt/homebrew/bin"
-        	export PATH="$PATH:/opt/homebrew/opt/node@18/bin"
-                export JAVA_HOME=/usr/libexec/java_home
-                export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
+        export PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
+        export PATH="$PATH:/etc/profiles/per-user/${config.home.username}/bin"
+        export PATH="$PATH:/opt/homebrew/bin"
+        export PATH="$PATH:/opt/homebrew/opt/node@18/bin"
+        export JAVA_HOME=/usr/libexec/java_home
+        # TODO: verify if this is at all needed at all needed
+        export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
       ''
     else
       ''

--- a/configs/bash/default.nix
+++ b/configs/bash/default.nix
@@ -16,7 +16,6 @@ in
         export PATH="$PATH:/opt/homebrew/bin"
         export PATH="$PATH:/opt/homebrew/opt/node@18/bin"
         export JAVA_HOME=/usr/libexec/java_home
-        # TODO: verify if this is at all needed at all needed
         export PASSWORD_STORE_DIR="/Users/${config.home.username}/.password-store"
       ''
     else

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -64,7 +64,6 @@ in
         set PATH $PATH /opt/homebrew/bin
         set PATH $PATH /opt/homebrew/opt/node@18/bin
         set JAVA_HOME /usr/libexec/java_home
-        # TODO: verify if this is at all needed at all needed
         set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
       ''
     else

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -58,13 +58,14 @@ in
     '' +
     (if isDarwin then
       ''
-                # this is needed, otherwise darwin-rebuild wouldn't be in PATH
-                fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
-                set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
-                set PATH $PATH /opt/homebrew/bin
-        	set PATH $PATH /opt/homebrew/opt/node@18/bin
-                set JAVA_HOME /usr/libexec/java_home
-                set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
+        # this is needed, otherwise darwin-rebuild wouldn't be in PATH
+        fish_add_path --prepend --global "$HOME/.nix-profile/bin" /nix/var/nix/profiles/default/bin /run/current-system/sw/bin
+        set PATH $PATH /etc/profiles/per-user/${config.home.username}/bin
+        set PATH $PATH /opt/homebrew/bin
+        set PATH $PATH /opt/homebrew/opt/node@18/bin
+        set JAVA_HOME /usr/libexec/java_home
+        # TODO: verify if this is at all needed at all needed
+        set PASSWORD_STORE_DIR /Users/${config.home.username}/.password-store
       ''
     else
       ''

--- a/configs/gopass/default.nix
+++ b/configs/gopass/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }: {
   home.file.".config/gopass/config".text =
-  ''
-    [mounts]
-        path = ${config.home.homeDirectory}/.password-store
-  '';
+    ''
+      [mounts]
+          path = ${config.home.homeDirectory}/.password-store
+    '';
 }

--- a/configs/gopass/default.nix
+++ b/configs/gopass/default.nix
@@ -1,16 +1,7 @@
-{ config, pkgs, ... }:
-let
-  isDarwin = pkgs.stdenv.isDarwin;
-in
-{
+{ config, pkgs, ... }: {
   home.file.".config/gopass/config".text =
-    if isDarwin then ''
-      [mounts]
-          path = ${config.home.homeDirectory}/.password-store
-    ''
-    else
-      ''
-        [mounts]
-            path = ${config.home.homeDirectory}/.local/share/.password-store
-      '';
+  ''
+    [mounts]
+        path = ${config.home.homeDirectory}/.password-store
+  '';
 }

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,9 @@
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
             home-manager.users.rounak = {
-              imports = [ ./hosts/ninezeroes/home.nix ];
+              imports = [
+                ./hosts/ninezeroes/home.nix
+              ];
               _module.args.self = self;
               _module.args.host = "ninezeroes";
               _module.args.inputs = inputs;

--- a/hosts/ckmac/configuration.nix
+++ b/hosts/ckmac/configuration.nix
@@ -1,4 +1,4 @@
-{ inputs, config, pkgs, ... }:
+{ inputs, config, pkgs, lib, ... }:
 
 {
   nix.settings = {

--- a/hosts/ckmac/home.nix
+++ b/hosts/ckmac/home.nix
@@ -2,6 +2,7 @@
 
   imports = [
     ../../configs
+    ../commons/pass.nix
   ];
 
   home = {

--- a/hosts/commons/pass.nix
+++ b/hosts/commons/pass.nix
@@ -1,28 +1,28 @@
 { config, pkgs, ... }: {
-    home.activation = {
-        passwordStore = ''
-            PW_DIR=${config.home.homeDirectory}/.password-store
+  home.activation = {
+    passwordStore = ''
+      PW_DIR=${config.home.homeDirectory}/.password-store
 
-            if [ ! -d "$PW_DIR" ]; then
-                mkdir -p "$PW_DIR"
-            fi
-            cd $PW_DIR
+      if [ ! -d "$PW_DIR" ]; then
+          mkdir -p "$PW_DIR"
+      fi
+      cd $PW_DIR
 
-            # the following PATH addition is to make sure that binaries like `git`, `emacs`, `ssh` are available for use
-            export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
+      # the following PATH addition is to make sure that binaries like `git`, `emacs`, `ssh` are available for use
+      export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
 
-            git init
-            if git remote | grep -q origin; then
-                git remote set-url origin git@gitlab.com:rounakdatta/pass.git
-            else
-                git remote add origin git@gitlab.com:rounakdatta/pass.git
-            fi
+      git init
+      if git remote | grep -q origin; then
+          git remote set-url origin git@gitlab.com:rounakdatta/pass.git
+      else
+          git remote add origin git@gitlab.com:rounakdatta/pass.git
+      fi
 
-            git fetch origin
-            git pull origin master
+      git fetch origin
+      git pull origin master
 
-            gopass-jsonapi configure --browser chrome --global=false --path=${config.home.homeDirectory}/.config/gopass
-            gopass-jsonapi configure --browser firefox --global=false --path=${config.home.homeDirectory}/.config/gopass
-        '';
-    };
+      gopass-jsonapi configure --browser chrome --global=false --path=${config.home.homeDirectory}/.config/gopass
+      gopass-jsonapi configure --browser firefox --global=false --path=${config.home.homeDirectory}/.config/gopass
+    '';
+  };
 }

--- a/hosts/commons/pass.nix
+++ b/hosts/commons/pass.nix
@@ -1,0 +1,28 @@
+{ config, pkgs, ... }: {
+    home.activation = {
+        passwordStore = ''
+            PW_DIR=${config.home.homeDirectory}/.password-store
+
+            if [ ! -d "$PW_DIR" ]; then
+                mkdir -p "$PW_DIR"
+            fi
+            cd $PW_DIR
+
+            # the following PATH addition is to make sure that binaries like `git`, `emacs`, `ssh` are available for use
+            export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
+
+            git init
+            if git remote | grep -q origin; then
+                git remote set-url origin git@gitlab.com:rounakdatta/pass.git
+            else
+                git remote add origin git@gitlab.com:rounakdatta/pass.git
+            fi
+
+            git fetch origin
+            git pull origin master
+
+            gopass-jsonapi configure --browser chrome --global=false --path=${config.home.homeDirectory}/.config/gopass
+            gopass-jsonapi configure --browser firefox --global=false --path=${config.home.homeDirectory}/.config/gopass
+        '';
+    };
+}

--- a/hosts/commons/pass.nix
+++ b/hosts/commons/pass.nix
@@ -10,6 +10,8 @@
 
       # the following PATH addition is to make sure that binaries like `git`, `emacs`, `ssh` are available for use
       export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
+      # `ssh` is on the following path in darwin, so there we go
+      export PATH="/usr/bin:$PATH"
 
       git init
       if git remote | grep -q origin; then

--- a/hosts/ninezeroes/home.nix
+++ b/hosts/ninezeroes/home.nix
@@ -2,6 +2,7 @@
 
   imports = [
     ../../configs
+    ../commons/pass.nix
   ];
 
   home = {


### PR DESCRIPTION
- [x] Makes password store directory consistent across NixOS and macOS
- [x] Sets up password store directory from git
- [ ] ~Sets up gnupg public/private keys~

Not doing the third point, given its complexity. Explored [sops-nix](https://github.com/Mic92/sops-nix) which is undoubtedly a pretty neat solution for managing secrets, alas the effort-to-impact ratio is too low here.