### PR TITLE
Hierarchical Claude skills via per-session plugin overlay

### DIFF
--- a/configs/claude-skills/default.nix
+++ b/configs/claude-skills/default.nix
@@ -38,6 +38,26 @@ in
         mkdir -p "$GENERATED_SKILLS_DIR"
         mkdir -p "$(dirname "$MANAGED_LINKS_FILE")"
 
+        expand_path() {
+          case "$1" in
+            "~")
+              printf '%s\n' "$HOME"
+              ;;
+            "~/"*)
+              printf '%s/%s\n' "$HOME" "''${1#"~/"}"
+              ;;
+            *)
+              printf '%s\n' "$1"
+              ;;
+          esac
+        }
+
+        root_skill_destination() {
+          root="$(expand_path "$1")"
+          root="''${root%/}"
+          printf '%s/.claude/skills\n' "$root"
+        }
+
         if [ ! -d "$CACHE_DIR" ]; then
           git clone -b ${cfg.privateRepo.ref} ${cfg.privateRepo.url} "$CACHE_DIR"
         else
@@ -68,15 +88,56 @@ in
           # Optional skill metadata:
           # {
           #   "enabled": true,
-          #   "destinations": ["~/.claude/skills", "~/work/byoc/.claude/skills"],
+          #   "global": false,
+          #   "roots": ["~/work/byoc"],
           #   "source": "https://github.com/owner/repo/tree/main/path/to/skill"
           # }
+          #
+          # Legacy "destinations" is still supported for exact install paths.
           if [ -f "$manifest" ]; then
             enabled="$("$JQ_BIN" -r '.enabled // true' "$manifest" 2>/dev/null || echo true)"
             if [ "$enabled" != "true" ]; then
               continue
             fi
-            destinations="$("$JQ_BIN" -r '(.destinations // ["~/.claude/skills"])[]' "$manifest" 2>/dev/null || echo "~/.claude/skills")"
+
+            if "$JQ_BIN" -e 'has("destinations")' "$manifest" >/dev/null 2>&1; then
+              destinations="$("$JQ_BIN" -r '(.destinations // [])[]' "$manifest" 2>/dev/null || true)"
+            else
+              destinations=""
+
+              if "$JQ_BIN" -e '.global == true' "$manifest" >/dev/null 2>&1; then
+                destinations="$SKILLS_DIR"
+              fi
+
+              roots="$("$JQ_BIN" -r '
+                def as_list:
+                  if type == "array" then .[]
+                  elif type == "string" then .
+                  else empty
+                  end;
+                (.roots // .projectRoots // .root // []) | as_list
+              ' "$manifest" 2>/dev/null || true)"
+
+              if [ -n "$roots" ]; then
+                root_destinations="$(printf '%s\n' "$roots" | while IFS= read -r root; do
+                  [ -n "$root" ] || continue
+                  root_skill_destination "$root"
+                done)"
+                if [ -n "$root_destinations" ]; then
+                  if [ -n "$destinations" ]; then
+                    destinations="$(printf '%s\n%s' "$destinations" "$root_destinations")"
+                  else
+                    destinations="$root_destinations"
+                  fi
+                fi
+              fi
+
+              if [ -z "$destinations" ]; then
+                echo "No global or roots configured for $skill_name; defaulting to user skills"
+                destinations="$SKILLS_DIR"
+              fi
+            fi
+
             source="$("$JQ_BIN" -r '.source // empty' "$manifest" 2>/dev/null || true)"
           fi
 
@@ -145,25 +206,16 @@ in
             resolved_skill_dir="$generated_skill_dir"
           fi
 
-          while IFS= read -r destination; do
+          printf '%s\n' "$destinations" | while IFS= read -r destination; do
             [ -n "$destination" ] || continue
 
-            case "$destination" in
-              "~")
-                destination="$HOME"
-                ;;
-              "~/"*)
-                destination="$HOME/''${destination#"~/"}"
-                ;;
-            esac
+            destination="$(expand_path "$destination")"
 
             mkdir -p "$destination"
             target="$destination/$skill_name"
             ln -sfn "$resolved_skill_dir" "$target"
             echo "$target" >> "$MANAGED_LINKS_FILE"
-          done <<EOF
-        $destinations
-        EOF
+          done
         done < <(
           if [ -d "$CACHE_DIR" ]; then
             find "$CACHE_DIR" \( -type f -name 'skill.json' -o -type f -name 'SKILL.md' \) -print0 | xargs -0 -I{} dirname "{}" | sort -u

--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -5,6 +5,161 @@
 }:
 let
   homeDir = config.home.homeDirectory;
+  claudeWrapperScript = ''
+    set -euo pipefail
+
+    REAL_CLAUDE="''${CLAUDE_REAL_BINARY:-/opt/homebrew/bin/claude}"
+
+    case "''${1:-}" in
+      -h | --help | -v | --version | auth | auto-mode | doctor | install | mcp | plugin | plugins | setup-token | update | upgrade)
+        exec "$REAL_CLAUDE" "$@"
+        ;;
+    esac
+
+    for arg in "$@"; do
+      case "$arg" in
+        --bare)
+          exec "$REAL_CLAUDE" "$@"
+          ;;
+      esac
+    done
+
+    if [ "''${CLAUDE_HIERARCHICAL_SKILLS_DISABLE:-}" = "1" ]; then
+      exec "$REAL_CLAUDE" "$@"
+    fi
+
+    if [ ! -x "$REAL_CLAUDE" ]; then
+      printf 'claude wrapper: real Claude binary not executable: %s\n' "$REAL_CLAUDE" >&2
+      exit 127
+    fi
+
+    canonical_dir() {
+      (
+        cd "$1" 2>/dev/null && pwd -P
+      )
+    }
+
+    HOME_REAL="$(canonical_dir "''${HOME:-.}" || printf '%s\n' "''${HOME:-}")"
+    PWD_REAL="$(pwd -P)"
+
+    ancestor_skill_dirs=()
+    current="$PWD_REAL"
+
+    while [ "$current" != "/" ]; do
+      if [ -n "$HOME_REAL" ] && [ "$current" = "$HOME_REAL" ]; then
+        break
+      fi
+
+      skill_dir="$current/.claude/skills"
+      if [ -d "$skill_dir" ]; then
+        ancestor_skill_dirs+=("$skill_dir")
+      fi
+
+      parent="$(dirname "$current")"
+      if [ "$parent" = "$current" ]; then
+        break
+      fi
+      current="$parent"
+    done
+
+    if [ "''${#ancestor_skill_dirs[@]}" -eq 0 ]; then
+      if [ "''${CLAUDE_HIERARCHICAL_SKILLS_PRINT:-}" = "1" ]; then
+        printf 'real=%s\n' "$REAL_CLAUDE"
+        printf 'overlay=\n'
+        printf 'skills=0\n'
+        printf 'argv:'
+        printf ' %q' "$REAL_CLAUDE" "$@"
+        printf '\n'
+        exit 0
+      fi
+      exec "$REAL_CLAUDE" "$@"
+    fi
+
+    overlay_hash="$(printf '%s' "$PWD_REAL" | sha256sum | cut -d ' ' -f 1 | cut -c 1-16)"
+    overlay_parent="$HOME/.cache/claude-skill-overlays"
+    overlay_root="$overlay_parent/$overlay_hash.$$"
+    overlay_skills="$overlay_root/skills"
+    plugin_manifest="$overlay_root/.claude-plugin/plugin.json"
+
+    mkdir -p "$overlay_parent"
+    # Best-effort prune of orphaned per-session overlays older than a week.
+    find "$overlay_parent" -mindepth 1 -maxdepth 1 -type d -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+
+    mkdir -p "$overlay_skills"
+    mkdir -p "$(dirname "$plugin_manifest")"
+    printf '%s\n' \
+      '{' \
+      '  "name": "hierarchical-skills",' \
+      '  "version": "0.1.0",' \
+      '  "author": {' \
+      '    "name": "dotfiles"' \
+      '  },' \
+      '  "description": "Session-only inherited skills assembled by the dotfiles Claude wrapper"' \
+      '}' > "$plugin_manifest"
+
+    declare -A seen_skills=()
+    selected_count=0
+
+    shopt -s nullglob
+    for skill_dir in "''${ancestor_skill_dirs[@]}"; do
+      for skill_path in "$skill_dir"/*; do
+        [ -d "$skill_path" ] || [ -L "$skill_path" ] || continue
+        [ -f "$skill_path/SKILL.md" ] || continue
+
+        skill_name="$(basename "$skill_path")"
+        if [ -n "''${seen_skills[$skill_name]+x}" ]; then
+          continue
+        fi
+
+        target="$overlay_skills/$skill_name"
+        ln -sfn "$(realpath "$skill_path")" "$target"
+        seen_skills["$skill_name"]=1
+        selected_count=$((selected_count + 1))
+      done
+    done
+    shopt -u nullglob
+
+    if [ "$selected_count" -eq 0 ]; then
+      rm -rf "$overlay_root"
+      if [ "''${CLAUDE_HIERARCHICAL_SKILLS_PRINT:-}" = "1" ]; then
+        printf 'real=%s\n' "$REAL_CLAUDE"
+        printf 'overlay=\n'
+        printf 'skills=0\n'
+        printf 'argv:'
+        printf ' %q' "$REAL_CLAUDE" "$@"
+        printf '\n'
+        exit 0
+      fi
+      exec "$REAL_CLAUDE" "$@"
+    fi
+
+    if [ "''${CLAUDE_HIERARCHICAL_SKILLS_DEBUG:-}" = "1" ]; then
+      printf 'claude wrapper: inherited skill overlay: %s\n' "$overlay_root" >&2
+      printf 'claude wrapper: ancestor skill dirs:\n' >&2
+      printf '  %s\n' "''${ancestor_skill_dirs[@]}" >&2
+    fi
+
+    if [ "''${CLAUDE_HIERARCHICAL_SKILLS_PRINT:-}" = "1" ]; then
+      printf 'real=%s\n' "$REAL_CLAUDE"
+      printf 'overlay=%s\n' "$overlay_root"
+      printf 'skills=%s\n' "$selected_count"
+      find "$overlay_skills" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -print | sort
+      printf 'argv:'
+      printf ' %q' "$REAL_CLAUDE" --plugin-dir "$overlay_root" "$@"
+      printf '\n'
+      exit 0
+    fi
+
+    exec "$REAL_CLAUDE" --plugin-dir "$overlay_root" "$@"
+  '';
+  claudeWrapper = pkgs.writeShellApplication {
+    name = "claude";
+    runtimeInputs = with pkgs; [
+      coreutils
+      findutils
+    ];
+    text = claudeWrapperScript;
+  };
 
   # Claude Code settings as a Nix attrset for better maintainability
   claudeSettings = {
@@ -141,6 +296,10 @@ let
   };
 in
 {
+  home.packages = lib.optionals pkgs.stdenv.isDarwin [
+    claudeWrapper
+  ];
+
   # Create ~/.claude directory and settings.json
   home.file.".claude/settings.json" = {
     text = builtins.toJSON claudeSettings;

--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -62,10 +62,45 @@ let
       current="$parent"
     done
 
-    # Drop the closest ancestor: Claude already loads it natively as project-scope skills.
-    # The wrapper only contributes the ancestors *above* it, which Claude wouldn't discover.
-    if [ "''${#ancestor_skill_dirs[@]}" -gt 0 ]; then
-      ancestor_skill_dirs=("''${ancestor_skill_dirs[@]:1}")
+    # Compute Claude's native project-scope reach so the wrapper supplies only
+    # what's outside it. Claude reads <cwd>/.claude/skills/ unconditionally,
+    # then walks up while each ancestor has CLAUDE.md, picking up each
+    # ancestor's .claude/skills/. The wrapper plugin overlay handles only
+    # the ancestors that fall *outside* this reach. Set
+    # CLAUDE_HIERARCHICAL_SKILLS_NO_DEDUP=1 to disable and supply everything.
+    declare -A claude_native_skill_dirs=()
+    if [ "''${CLAUDE_HIERARCHICAL_SKILLS_NO_DEDUP:-}" != "1" ]; then
+      if [ -d "$PWD_REAL/.claude/skills" ]; then
+        claude_native_skill_dirs["$PWD_REAL/.claude/skills"]=1
+      fi
+      walk_current="$PWD_REAL"
+      while [ "$walk_current" != "/" ]; do
+        if [ ! -f "$walk_current/CLAUDE.md" ]; then
+          break
+        fi
+        walk_parent="$(dirname "$walk_current")"
+        if [ "$walk_parent" = "$walk_current" ]; then
+          break
+        fi
+        if [ -n "$HOME_REAL" ] && [ "$walk_parent" = "$HOME_REAL" ]; then
+          break
+        fi
+        if [ -d "$walk_parent/.claude/skills" ]; then
+          claude_native_skill_dirs["$walk_parent/.claude/skills"]=1
+        fi
+        walk_current="$walk_parent"
+      done
+    fi
+
+    filtered_skill_dirs=()
+    for d in "''${ancestor_skill_dirs[@]}"; do
+      if [ -z "''${claude_native_skill_dirs[$d]+x}" ]; then
+        filtered_skill_dirs+=("$d")
+      fi
+    done
+    ancestor_skill_dirs=()
+    if [ "''${#filtered_skill_dirs[@]}" -gt 0 ]; then
+      ancestor_skill_dirs=("''${filtered_skill_dirs[@]}")
     fi
 
     if [ "''${#ancestor_skill_dirs[@]}" -eq 0 ]; then

--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -62,6 +62,12 @@ let
       current="$parent"
     done
 
+    # Drop the closest ancestor: Claude already loads it natively as project-scope skills.
+    # The wrapper only contributes the ancestors *above* it, which Claude wouldn't discover.
+    if [ "''${#ancestor_skill_dirs[@]}" -gt 0 ]; then
+      ancestor_skill_dirs=("''${ancestor_skill_dirs[@]:1}")
+    fi
+
     if [ "''${#ancestor_skill_dirs[@]}" -eq 0 ]; then
       if [ "''${CLAUDE_HIERARCHICAL_SKILLS_PRINT:-}" = "1" ]; then
         printf 'real=%s\n' "$REAL_CLAUDE"


### PR DESCRIPTION
## Summary

- Route private skills by per-skill metadata: `global: true` → `~/.claude/skills`, `roots: ["~/work", ...]` → `<root>/.claude/skills` for each root. Legacy `destinations` is still honored for exact paths.
- New `claude` shell wrapper walks ancestors of `pwd -P`, collects each `<ancestor>/.claude/skills`, and launches the real claude with a session-only `--plugin-dir` overlay. Closer ancestor wins on dedup, and skill entries in the overlay are symlinks (via `realpath`) into the canonical agent-smith cache — no per-launch deep copies.
- Overlay path is PID-suffixed (`<hash>.<pid>`) so simultaneous launches in the same directory can't race on `rm -rf`. Orphaned session overlays older than 7 days are pruned at the start of each launch.

Companion change in agent-smith: [`Migrate skills to roots/global schema for hierarchical loading`](https://github.com/rounakdatta/agent-smith/commit/20222c8) — all skill manifests migrated; the new dotfiles activation logic still accepts the legacy field for back-compat.

## Test plan

- [x] `nix build .#darwinConfigurations.trueswiftie.system --no-link` — flake evaluates and `writeShellApplication`'s shellcheck pass succeeds
- [x] `sudo darwin-rebuild switch` — activation runs cleanly, managed-links replay deletes stale `~/.claude/skills/lyric-*` symlinks, fresh `~/work/.claude/skills/` is populated
- [x] `~/.claude/skills/`, `~/work/.claude/skills/`, `~/work/byoc/.claude/skills/`, `~/personal/.claude/skills/` all reflect expected layout
- [x] `CLAUDE_HIERARCHICAL_SKILLS_PRINT=1 claude` from `~`, `~/personal/dotfiles`, `~/work`, `~/work/byoc` returns 0/5/3/6 skills respectively
- [x] Overlay entries are symlinks resolving to `~/.cache/agent-smith/<skill>` (not copies)
- [x] Two back-to-back launches from the same dir produce overlays with distinct `.PID` suffixes
- [x] HOW_TO `CLAUDE.md` sync still works (`~/work/CLAUDE.md`, `~/work/byoc/CLAUDE.md` populated)

## Escape hatches

- `CLAUDE_HIERARCHICAL_SKILLS_DISABLE=1 claude` — bypasses the wrapper, execs the real binary directly.
- `CLAUDE_HIERARCHICAL_SKILLS_DEBUG=1 claude` — prints the chosen overlay path and ancestor dirs to stderr before launch.
- `CLAUDE_HIERARCHICAL_SKILLS_PRINT=1 claude` — dry-run; prints intended invocation and exits.
- `CLAUDE_REAL_BINARY=/path/to/claude` — overrides the default `/opt/homebrew/bin/claude`.
- `claude --bare …` — also bypasses the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)