### PR TITLE
Add strava and hevy MCP servers, plus monitorcontrol and supercmd brew casks

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -298,6 +298,30 @@ let
               "https://mcp-server.zomato.com/mcp"
             ];
           };
+          strava = {
+            command = "bash";
+            args = [
+              "-c"
+              ''
+                exec env \
+                  STRAVA_CLIENT_ID="$(pass show api-keys/strava-client-id)" \
+                  STRAVA_CLIENT_SECRET="$(pass show api-keys/strava-client-secret)" \
+                  STRAVA_ACCESS_TOKEN="$(pass show api-keys/strava-access-token)" \
+                  STRAVA_REFRESH_TOKEN="$(pass show api-keys/strava-refresh-token)" \
+                  npx -y @r-huijts/strava-mcp-server
+              ''
+            ];
+          };
+          hevy = {
+            command = "bash";
+            args = [
+              "-c"
+              ''
+                exec env HEVY_API_KEY="$(pass show api-keys/hevy)" \
+                  npx -y hevy-mcp
+              ''
+            ];
+          };
         };
       }
       {

--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -151,6 +151,7 @@
       "rana-gmbh/netfluss/netfluss"
       "alienator88-sentinel"
       "monitorcontrol"
+      "supercmdlabs/supercmd/supercmd"
     ];
 
     # `mas search <>` can help pinpoint package name

--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -150,6 +150,7 @@
       "google-drive"
       "rana-gmbh/netfluss/netfluss"
       "alienator88-sentinel"
+      "monitorcontrol"
     ];
 
     # `mas search <>` can help pinpoint package name


### PR DESCRIPTION
## Summary

- Wire `strava` (via `@r-huijts/strava-mcp-server`) and `hevy` (via `hevy-mcp`) into the `~/personal` project-local MCP profile, alongside `zomato`. Credentials flow in from `pass` (four entries for Strava OAuth, one for Hevy).
- Add `monitorcontrol` and `supercmdlabs/supercmd/supercmd` to the trueswiftie homebrew casks list.

Both MCPs invoke via `npx -y` so there's no long-running server to manage. `supercmd` comes from the third-party `supercmdlabs/supercmd` tap; `brew bundle` auto-taps from the cask reference.

## Test plan

- [x] `nix build .#darwinConfigurations.trueswiftie.system --no-link` — flake evaluates and shellcheck passes
- [x] `pass insert` for all five Strava/Hevy entries and confirm decryption lengths match
- [x] `sudo darwin-rebuild switch --flake .#trueswiftie` — writes `strava` and `hevy` into `~/personal/.mcp.json`; brings in `monitorcontrol` and `supercmd` via the brewfile activation
- [x] `claude` from `~/personal` shows both MCP servers connected via `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)