### PR TITLE
Remove monitorcontrol brew cask

### DIFF
--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -150,7 +150,6 @@
       "google-drive"
       "rana-gmbh/netfluss/netfluss"
       "alienator88-sentinel"
-      "monitorcontrol"
       "supercmdlabs/supercmd/supercmd"
     ];
 


### PR DESCRIPTION
## Summary

- Drop `monitorcontrol` from the trueswiftie homebrew casks list, undoing the addition from #61.

## Test plan

- [x] `nix build .#darwinConfigurations.trueswiftie.system --no-link` — flake evaluates cleanly
- [ ] `sudo darwin-rebuild switch --flake .#trueswiftie` — confirm `brew bundle` uninstalls the cask on next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)