### PR TITLE
Add notprod-lyric-deploy MCP server

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -355,6 +355,12 @@ let
               ''
             ];
           };
+          notprod-lyric-deploy = {
+            command = "mic";
+            args = [
+              "mcp"
+            ];
+          };
         };
       }
     ];


### PR DESCRIPTION
## Summary
- Wires `mic mcp` into the `~/work` project-local MCP profile so Claude sessions launched under `~/work` pick up the Lyric deploy tooling alongside the existing Grafana servers.
- No secrets involved — `mic` handles its own auth.

## Test plan
- [ ] `sudo darwin-rebuild switch --flake .#trueswiftie` applies cleanly
- [ ] `~/work/.mcp.json` contains the new `notprod-lyric-deploy` entry alongside `notprod-grafana-lyric` and `prod-grafana-lyric`
- [ ] Launching Claude from a `~/work/...` repo lists `notprod-lyric-deploy` in `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)