### PR TITLE
Pass --force-cleanup to brew bundle so cleanup works on Homebrew 4.x

### DIFF
--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -26,7 +26,13 @@
       # zap: more aggressive cleanup but requires Full Disk Access permissions
       cleanup = "uninstall";
       upgrade = true;
-      extraFlags = [ "--verbose" ];
+      # --force-cleanup is required because Homebrew 4.x now refuses `brew bundle
+      # --cleanup` (which uninstalls casks/brews not in this file) unless an
+      # explicit force flag confirms the destructive cleanup. nix-darwin appends
+      # extraFlags to the bundle command, so this is the cleanest place for it.
+      # Without it, a fresh laptop (which bootstraps the newest brew) aborts
+      # activation with: `brew bundle install --cleanup` requires `--force` ...
+      extraFlags = [ "--verbose" "--force-cleanup" ];
     };
 
     # taps to open, let packages rain


### PR DESCRIPTION
## What

Homebrew 4.x now refuses `brew bundle --cleanup` (which uninstalls casks/brews not listed in `software.nix`) unless an explicit force flag confirms the destructive cleanup. nix-darwin appends `extraFlags` to the bundle command, so adding `--force-cleanup` there restores the intended cleanup behaviour — no nix-darwin bump required.

## Why

A fresh laptop bootstraps the newest brew, which enforces the new rule, so `darwin-rebuild` aborts at the Homebrew bundle step with:

> Error: Invalid usage: `brew bundle install --cleanup` requires `--force`, `--force-cleanup` or `$HOMEBREW_ASK`.

Existing machines had an older brew that accepted `--cleanup` alone — classic version skew that only surfaces on a first-time install.

## Verification

- `nixpkgs-fmt --check .` passes
- `nix eval --raw .#darwinConfigurations.trueswiftie.system` evaluates cleanly
- Generated activation command confirmed to be: `brew bundle --file='…/Brewfile' --cleanup --verbose --force-cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
