### PR TITLE
Make first-time password-store sync non-interactive and quiet

### DIFF
--- a/configs/pass/default.nix
+++ b/configs/pass/default.nix
@@ -8,9 +8,10 @@ in
   };
 
   home.activation = {
-    # best-effort and re-runnable: gitlab SSH access is set up out-of-band, so
-    # the clone only succeeds on a later switch. the subshell + `|| true` keeps
-    # any failure (and the `cd`) from aborting or leaking into the rest of activation
+    # best-effort, re-runnable store bootstrap. gitlab access is set up
+    # out-of-band, so the sync only succeeds on a later switch; the subshell
+    # (+ `|| true`) keeps any failure and the `cd` from leaking into the rest
+    # of activation.
     passwordStore = ''
       (
         PW_DIR=${passwordStoreDir}
@@ -29,11 +30,11 @@ in
             git remote add origin git@gitlab.com:rounakdatta/pass.git
         fi
 
-        # non-interactive: never block activation on an SSH host-key/passphrase
-        # prompt. quietly skip the sync until gitlab access is set up out-of-band
+        # BatchMode/accept-new so activation can't stall on an SSH host-key or
+        # passphrase prompt; point at the manual command rather than guessing why
         export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
         if ! { git fetch origin && git pull origin master; } >/dev/null 2>&1; then
-            echo "note: skipping password-store sync (gitlab access not ready); will sync on a later switch"
+            echo "note: password-store not synced; run 'git -C $PW_DIR pull' once gitlab access is set up"
         fi
 
         # browser integration needs an initialized store

--- a/configs/pass/default.nix
+++ b/configs/pass/default.nix
@@ -29,10 +29,18 @@ in
             git remote add origin git@gitlab.com:rounakdatta/pass.git
         fi
 
-        git fetch origin && git pull origin master
+        # non-interactive: never block activation on an SSH host-key/passphrase
+        # prompt. quietly skip the sync until gitlab access is set up out-of-band
+        export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+        if ! { git fetch origin && git pull origin master; } >/dev/null 2>&1; then
+            echo "note: skipping password-store sync (gitlab access not ready); will sync on a later switch"
+        fi
 
-        echo "Y" | gopass-jsonapi configure --browser chrome --global=false --path=${config.home.homeDirectory}/.config/gopass
-        echo "Y" | gopass-jsonapi configure --browser firefox --global=false --path=${config.home.homeDirectory}/.config/gopass
+        # browser integration needs an initialized store
+        if [ -f "$PW_DIR/.gpg-id" ]; then
+            echo "Y" | gopass-jsonapi configure --browser chrome --global=false --path=${config.home.homeDirectory}/.config/gopass
+            echo "Y" | gopass-jsonapi configure --browser firefox --global=false --path=${config.home.homeDirectory}/.config/gopass
+        fi
       ) || true
     '';
   };


### PR DESCRIPTION
Follow-up to #66. That PR stopped activation from *aborting* on a fresh machine, but the first-time run was still noisy and could block:

1. `git fetch` against gitlab triggered an **interactive SSH prompt** — `Are you sure you want to continue connecting (yes/no/[fingerprint])?` — which can hang non-interactive activation on stdin.
2. The expected clone failure dumped a `fatal: Could not read from remote repository`, and the `gopass-jsonapi configure` calls printed `Failed to initialize gopass API: password store not initialized` because they ran before the store existed.

## Fix (`configs/pass/default.nix`)

- Set `GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"` so the sync can never block on a host-key or passphrase prompt — it fails fast instead.
- Swallow the expected fetch/pull failure and print a single calm note instead of git's fatal dump.
- Only run `gopass-jsonapi configure` once the store is actually initialized (`.gpg-id` present), so the "not initialized" errors no longer appear.

## Behaviour

- **First switch (no gitlab access yet):** one-line note, no SSH prompt, no scary errors — activation stays clean.
- **Later switch (access set up):** store syncs and browser integration configures as before.

https://claude.ai/code/session_016hTresnEMCVAfPGAKqH8am

---
_Generated by [Claude Code](https://claude.ai/code/session_016hTresnEMCVAfPGAKqH8am)_