### PR TITLE
Reclaim gpg-agent socket for nix's GnuPG on darwin

### DIFF
--- a/configs/gnupg/default.nix
+++ b/configs/gnupg/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 let
   isDarwin = pkgs.stdenv.isDarwin;
 in
@@ -12,4 +12,16 @@ in
     pinentry.package = if isDarwin then pkgs.pinentry_mac else pkgs.pinentry-gnome3;
     enableSshSupport = !isDarwin;
   };
+
+  # GPG Suite (brew) ships gpg-agent 2.2.41 and auto-starts it, while nix's gpg
+  # is 2.4.9. Both share ~/.gnupg/S.gpg-agent, so gopass/git hit the older agent
+  # and decryption fails with "server gpg-agent is older than us" + "No secret
+  # key". Reclaim the socket for nix's matching agent (key material in ~/.gnupg
+  # is untouched). Uses nix's gpgconf explicitly so the relaunched agent is 2.4.9.
+  home.activation.useNixGpgAgent = lib.mkIf isDarwin (
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      "${pkgs.gnupg}/bin/gpgconf" --kill gpg-agent || true
+      "${pkgs.gnupg}/bin/gpgconf" --launch gpg-agent || true
+    ''
+  );
 }


### PR DESCRIPTION
Follow-up to #67. With the store now syncing, decryption fails on a fresh machine:

```
gpg: WARNING: server 'gpg-agent' is older than us (2.2.41 < 2.4.9)
gpg: public key decryption failed: No secret key
gpg: decryption failed: No secret key
```

## Root cause

Two GnuPG installs, sharing one agent socket:

- **nix** installs `gnupg` (`programs.gpg.enable`) → the **gpg 2.4.9** client gopass invokes.
- **Homebrew** installs the **`gpg-suite`** cask (`hosts/trueswiftie/software.nix`), which ships MacGPG2 → **gpg-agent 2.2.41**, auto-started at login.

Both use `~/.gnupg/S.gpg-agent`, and GPG Suite's older agent owns it. A 2.4.9 client talking to a 2.2.41 agent can't complete the private-key operation, so you get `No secret key` even though the key is in `~/.gnupg`.

## Fix

Keep GPG Suite (its GUI apps stay), but make nix's agent authoritative. A darwin-only activation step kills whatever agent holds the socket and relaunches nix's matching 2.4.9 agent, invoking nix's own `gpgconf` explicitly so the right binary wins:

```nix
home.activation.useNixGpgAgent = lib.mkIf isDarwin (
  lib.hm.dag.entryAfter [ "writeBoundary" ] ''
    "${pkgs.gnupg}/bin/gpgconf" --kill gpg-agent || true
    "${pkgs.gnupg}/bin/gpgconf" --launch gpg-agent || true
  ''
);
```

Key material in `~/.gnupg` is untouched, and `services.gpg-agent` still claims the socket at login.

## Note on durability

This is the "keep GPG Suite" approach, so it isn't bulletproof: if a GPG Suite app (GPG Mail/Keychain) invokes its 2.2.41 `gpg` before nix's agent is up after a reboot, it can re-own the socket until the next `home-manager switch`. In practice the activation reclaim + login-time `services.gpg-agent` cover normal use. If this ever recurs, dropping the `gpg-suite` cask removes the conflict entirely.

https://claude.ai/code/session_016hTresnEMCVAfPGAKqH8am

---
_Generated by [Claude Code](https://claude.ai/code/session_016hTresnEMCVAfPGAKqH8am)_