### PR TITLE
Add declarative cargo-packages module for installing crates

### DIFF
--- a/configs/cargo/default.nix
+++ b/configs/cargo/default.nix
@@ -1,0 +1,41 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.programs.cargo-packages;
+in
+{
+  options.programs.cargo-packages = {
+    enable = lib.mkOption { type = lib.types.bool; default = true; };
+
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Crates to install via 'cargo install'. Each entry is passed verbatim
+        as the arguments to 'cargo install', so both registry crates
+        ("ripgrep", "cargo-edit --version 0.12") and git sources
+        ("--git https://github.com/owner/repo") are supported.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.packages != [ ]) {
+    home.sessionPath = [ "${config.home.homeDirectory}/.cargo/bin" ];
+
+    home.activation.cargoInstall = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      # /usr/bin is needed so `cargo install` finds the system `cc` (Xcode CLT)
+      # to link binaries; the activation PATH doesn't include it by default.
+      export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:/opt/homebrew/bin:$HOME/.cargo/bin:/usr/bin:$PATH"
+
+      if ! command -v cargo >/dev/null 2>&1; then
+        echo "Skipping cargo package install because cargo is unavailable"
+        exit 0
+      fi
+
+      ${lib.concatMapStringsSep "\n" (pkg: ''
+        echo "Installing ${pkg}..."
+        cargo install ${pkg} || true
+      '') cfg.packages}
+    '';
+  };
+}

--- a/configs/default.nix
+++ b/configs/default.nix
@@ -14,6 +14,7 @@
     ./emacs
     ./claude
     ./go
+    ./cargo
     ./claude-skills
     ./atuin
   ];

--- a/configs/fish/default.nix
+++ b/configs/fish/default.nix
@@ -13,6 +13,7 @@ in
       set GOPATH $HOME/go
       set PATH $GOPATH/bin $PATH
       set PATH $HOME/.npm-packages/bin $PATH
+      set PATH $HOME/.cargo/bin $PATH
       set EDITOR nvim
       set SHELL /run/current-system/sw/bin/fish
       set XDG_DATA_HOME /run/current-system/sw/share/X11

--- a/hosts/trueswiftie/home.nix
+++ b/hosts/trueswiftie/home.nix
@@ -41,6 +41,11 @@
       nixd
       nil
 
+      # rust toolchain backing programs.cargo-packages; `cargo install` builds
+      # from source, so it leans on the system linker (Xcode CLT) for the cc step
+      cargo
+      rustc
+
       # google cloud sdk via nix (not the brew cask): bundles its own python so
       # gcloud never trips over macOS's system python 3.9, and lets us declare
       # the gke auth plugin instead of `gcloud components install` at activation.
@@ -116,6 +121,10 @@
 
     go-packages.packages = [
       "github.com/blacktop/mcp-tts@latest"
+    ];
+
+    cargo-packages.packages = [
+      "--git https://github.com/fu5ha/zed-workspaces"
     ];
   };
 }


### PR DESCRIPTION
## What

Adds a declarative `programs.cargo-packages` home-manager module, mirroring the
existing `go-packages` / `npm-packages` modules — so Rust crates can be listed
in one place and installed via `cargo install` at activation time.

```nix
cargo-packages.packages = [
  "ripgrep"                                       # registry crate
  "cargo-edit --version 0.12"                     # pinned
  "--git https://github.com/fu5ha/zed-workspaces" # git source
];
```

## Why this design

- **Verbatim args.** Each list entry is passed straight to `cargo install`, so
  registry crates, version pins, `--locked`, features, and `--git` sources all
  work with zero extra option surface — the same idiom as `go-packages`.
- **Safe by default.** Guarded on `command -v cargo` (no-ops if Rust is absent)
  and per-crate `|| true` (a failed build never aborts a `darwin-rebuild
  switch`).
- **Linker fix.** The activation PATH includes `/usr/bin` so `cargo install`
  finds the system `cc` (Xcode CLT) to locate the macOS SDK and link binaries —
  without it, builds compile fully then die at the link step.

## Changes

- `configs/cargo/default.nix` — new module.
- `configs/default.nix` — import `./cargo`.
- `hosts/trueswiftie/home.nix` — add nixpkgs `cargo` + `rustc`, plus the
  `zed-workspaces` install as the first consumer.

## Verification

- `nixpkgs-fmt --check .` clean.
- `nix eval --raw .#darwinConfigurations.trueswiftie.system` evaluates.
- Reproduced the link failure (`rustc` with an activation-like PATH missing
  `/usr/bin`) and confirmed a minimal program links once `/usr/bin` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
