### PR TITLE
Trust third-party Homebrew taps before brew bundle (Homebrew 6)

### DIFF
--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -1,6 +1,38 @@
-{ pkgs, ... }:
+{ pkgs, config, lib, ... }:
+let
+  # Homebrew 6 refuses to load formulae/casks from non-official ("untrusted")
+  # taps unless they're explicitly trusted (https://docs.brew.sh/Tap-Trust).
+  # nix-darwin's homebrew module has no trust option yet, so mirror what
+  # nix-homebrew's tap-trust support does (zhaofengli/nix-homebrew#157): run
+  # `brew trust --tap <tap>` for every third-party tap this config pulls from,
+  # before `brew bundle` runs (extraActivation precedes the homebrew phase).
+  # Trusting the whole tap is appropriate here: if it's in this file, we vouch
+  # for it. Tap names are lowercased to match how Homebrew normalizes them.
+  tapName = t: if builtins.isString t then t else t.name;
+  # "user/repo/leaf" (a fully-qualified brew/cask) -> [ "user/repo" ]; else [ ].
+  qualifiedTap = s:
+    let parts = lib.splitString "/" s;
+    in lib.optional (builtins.length parts >= 3)
+      (lib.toLower "${builtins.elemAt parts 0}/${builtins.elemAt parts 1}");
+  trustedTaps = lib.unique (
+    (map (t: lib.toLower (tapName t)) config.homebrew.taps)
+    ++ lib.concatMap (b: qualifiedTap (tapName b)) config.homebrew.brews
+    ++ lib.concatMap (c: qualifiedTap (tapName c)) config.homebrew.casks
+  );
+in
 {
   system.stateVersion = 5;
+
+  # Trust the declared third-party taps before `brew bundle` (see trustedTaps).
+  # Guarded + best-effort so it never aborts activation (and is a no-op on a
+  # brew old enough to predate the trust gate, which also lacks `brew trust`).
+  system.activationScripts.extraActivation.text = lib.mkAfter ''
+    if [ -x /opt/homebrew/bin/brew ]; then
+      for tap in ${lib.escapeShellArgs trustedTaps}; do
+        /opt/homebrew/bin/brew trust --tap "$tap" >/dev/null 2>&1 || true
+      done
+    fi
+  '';
 
   environment = {
     # this is so that fish gets added to /etc/shells


### PR DESCRIPTION
## Problem

Homebrew 6 added a tap-trust gate (https://docs.brew.sh/Tap-Trust): it refuses to load formulae/casks from non-official taps unless they're explicitly trusted. `darwin-rebuild switch` now fails during `brew bundle` with e.g.:

> Error: Refusing to load formula fairwindsops/tap/rbac-lookup from untrusted tap fairwindsops/tap.

## Fix

nix-darwin's `homebrew` module has no trust option, so this mirrors nix-homebrew's tap-trust support ([zhaofengli/nix-homebrew#157](https://github.com/zhaofengli/nix-homebrew/pull/157)): an `extraActivation` step (which runs *before* the homebrew bundle phase) runs `brew trust --tap <tap>` for every third-party tap this config pulls from.

The tap set is derived from `homebrew.taps` **plus** the taps behind fully-qualified `brews`/`casks` — so `oven-sh/bun` and `supercmdlabs/supercmd` are covered, not just the declared taps — and lowercased to match Homebrew's normalization:

```
fairwindsops/tap  rajatjindal/tap  metalbear-co/mirrord  cue-lang/tap
lyric-tech/mic  guumaster/tap  rana-gmbh/netfluss  oven-sh/bun  supercmdlabs/supercmd
```

Guarded (`if brew exists`) and best-effort (`|| true`) so it never aborts activation and no-ops on a pre-6 brew.

## Verified

- Darwin builds; the rendered `extraActivation` keeps the existing rosetta step (clean `mkAfter` merge) and adds the trust loop with all 9 taps.
- Darwin-only — `software.nix` isn't imported by the NixOS host, so no cross-platform impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
