### PR TITLE
Add Claude Pets screen saver (idle-screen counterpart to the overlay)

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -18,5 +18,6 @@
     ./claude-skills
     ./atuin
     ./hammerspoon
+    ./screensaver
   ];
 }

--- a/configs/screensaver/Info.plist
+++ b/configs/screensaver/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleExecutable</key><string>ClaudePets</string>
+  <key>CFBundleIdentifier</key><string>com.rounak.claudepets</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>ClaudePets</string>
+  <key>CFBundlePackageType</key><string>BNDL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>NSPrincipalClass</key><string>ClaudePetsView</string>
+</dict>
+</plist>

--- a/configs/screensaver/claude-pets.m
+++ b/configs/screensaver/claude-pets.m
@@ -1,0 +1,223 @@
+// Claude Pets screen saver
+//
+// The lock/idle-screen counterpart to the Hammerspoon desk-pet overlay. It
+// reads the very same registry the overlay does — ~/.cache/claude-sessions,
+// written by the claude-session-tracker hook (see configs/claude) — and draws
+// the same two squads of Claude Code bots:
+//
+//   * WAITING (orange, across the top) — sessions needing you (attention/asking),
+//     bobbing gently.
+//   * WORKING (grey, down the left edge, vertically centered) — sessions
+//     currently working, vibrating gently.
+//
+// It runs inside the sandboxed legacyScreenSaver host, whose NSHomeDirectory()
+// is redirected to a container — so we resolve the REAL home via getpwuid() and
+// read the registry by absolute path (the host carries broad file entitlements,
+// confirmed to allow this).
+//
+// Nix bundles claudecode-color.png / claudecode-gray.png (shared with the
+// Hammerspoon overlay) into Contents/Resources, loaded by name below.
+
+#import <ScreenSaver/ScreenSaver.h>
+#import <Cocoa/Cocoa.h>
+#import <pwd.h>
+#import <unistd.h>
+
+static const NSTimeInterval kTTL = 28800;     // ignore sessions stale > 8h
+static const CGFloat kWaitSize = 88;          // orange waiting bot (pt)
+static const CGFloat kWorkSize = 58;          // grey working bot (pt)
+static const CGFloat kGap = 20;               // space between bots
+static const CGFloat kTopMargin = 80;         // waiting row gap below the top
+static const CGFloat kLeftMargin = 80;        // working column gap from the left
+static const CGFloat kBobAmpl = 9;            // waiting bob height (pt)
+static const CGFloat kBobPeriod = 2.6;        // waiting bob period (s)
+static const CGFloat kVibAmpl = 2;            // working vibrate amplitude (pt)
+static const CGFloat kVibPeriod = 0.5;        // working vibrate period (s)
+static const CGFloat kLabelFont = 15;
+static const NSInteger kReloadFrames = 60;    // re-read the registry every ~2s
+
+@interface ClaudePetsView : ScreenSaverView
+@property (nonatomic) double t;               // accumulated animation time (s)
+@property (nonatomic) NSInteger frameCount;
+@property (nonatomic, strong) NSImage *colorLogo;
+@property (nonatomic, strong) NSImage *grayLogo;
+@property (nonatomic, strong) NSArray<NSDictionary *> *waiting;
+@property (nonatomic, strong) NSArray<NSDictionary *> *working;
+@end
+
+@implementation ClaudePetsView
+
+- (instancetype)initWithFrame:(NSRect)frame isPreview:(BOOL)isPreview {
+  self = [super initWithFrame:frame isPreview:isPreview];
+  if (self) {
+    [self setAnimationTimeInterval:1.0 / 30.0];
+    _t = 0;
+    _frameCount = 0;
+    _waiting = @[];
+    _working = @[];
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    _colorLogo = [[NSImage alloc] initWithContentsOfFile:
+        [bundle pathForResource:@"claudecode-color" ofType:@"png"]];
+    _grayLogo = [[NSImage alloc] initWithContentsOfFile:
+        [bundle pathForResource:@"claudecode-gray" ofType:@"png"]];
+    [self reloadSessions];
+  }
+  return self;
+}
+
+// ----------------------------------------------------------- registry read --
+
+- (NSString *)registryDir {
+  // NSHomeDirectory() is the sandbox container here; getpwuid gives the real
+  // home, which the host is entitled to read.
+  struct passwd *pw = getpwuid(getuid());
+  NSString *home = (pw && pw->pw_dir) ? @(pw->pw_dir) : NSHomeDirectory();
+  return [home stringByAppendingPathComponent:@".cache/claude-sessions"];
+}
+
+- (void)reloadSessions {
+  NSString *dir = [self registryDir];
+  NSFileManager *fm = [NSFileManager defaultManager];
+  NSArray<NSString *> *files = [fm contentsOfDirectoryAtPath:dir error:NULL];
+  NSTimeInterval now = [[NSDate date] timeIntervalSince1970];
+  NSMutableArray<NSDictionary *> *wait = [NSMutableArray array];
+  NSMutableArray<NSDictionary *> *work = [NSMutableArray array];
+
+  for (NSString *f in files) {
+    if (![f hasSuffix:@".json"]) {
+      continue;
+    }
+    NSData *data = [NSData dataWithContentsOfFile:[dir stringByAppendingPathComponent:f]];
+    if (!data) {
+      continue;
+    }
+    NSDictionary *d = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    if (![d isKindOfClass:[NSDictionary class]]) {
+      continue;
+    }
+    NSNumber *updated = d[@"updated_at"];
+    if (![updated isKindOfClass:[NSNumber class]] || now - updated.doubleValue > kTTL) {
+      continue;
+    }
+    NSString *state = d[@"state"];
+    if ([state isEqualToString:@"attention"] || [state isEqualToString:@"asking"]) {
+      [wait addObject:d];
+    } else if ([state isEqualToString:@"working"]) {
+      [work addObject:d];
+    }
+  }
+
+  NSComparator byTime = ^NSComparisonResult(NSDictionary *a, NSDictionary *b) {
+    double ua = [a[@"updated_at"] doubleValue], ub = [b[@"updated_at"] doubleValue];
+    return (ua < ub) ? NSOrderedAscending : (ua > ub) ? NSOrderedDescending : NSOrderedSame;
+  };
+  self.waiting = [wait sortedArrayUsingComparator:byTime];
+  self.working = [work sortedArrayUsingComparator:byTime];
+}
+
+// ------------------------------------------------------------------- draw --
+
+- (void)drawImage:(NSImage *)img inRect:(NSRect)r alpha:(CGFloat)a {
+  if (img) {
+    [img drawInRect:r
+           fromRect:NSZeroRect
+          operation:NSCompositingOperationSourceOver
+           fraction:a
+     respectFlipped:YES
+              hints:nil];
+  } else { // asset missing: fall back to a visible block so it's never silent
+    [[NSColor systemOrangeColor] set];
+    NSRectFill(NSInsetRect(r, r.size.width * 0.2, r.size.height * 0.2));
+  }
+}
+
+- (NSString *)labelFor:(NSDictionary *)session {
+  NSString *cwd = session[@"cwd"];
+  if ([cwd isKindOfClass:[NSString class]] && cwd.length > 0) {
+    return cwd.lastPathComponent;
+  }
+  return @"claude";
+}
+
+- (void)drawLabel:(NSString *)text centeredAt:(CGFloat)cx top:(CGFloat)top width:(CGFloat)w {
+  static NSDictionary *attrs = nil;
+  if (!attrs) {
+    NSMutableParagraphStyle *ps = [[NSMutableParagraphStyle alloc] init];
+    ps.alignment = NSTextAlignmentCenter;
+    ps.lineBreakMode = NSLineBreakByTruncatingTail;
+    attrs = @{
+      NSFontAttributeName : [NSFont systemFontOfSize:kLabelFont weight:NSFontWeightMedium],
+      NSForegroundColorAttributeName : [NSColor colorWithWhite:0.9 alpha:0.92],
+      NSParagraphStyleAttributeName : ps,
+    };
+  }
+  NSRect r = NSMakeRect(cx - w, top - kLabelFont - 4, w * 2, kLabelFont + 2);
+  [text drawInRect:r withAttributes:attrs];
+}
+
+- (void)drawRect:(NSRect)rect {
+  [[NSColor blackColor] set];
+  NSRectFill(rect);
+
+  NSRect b = self.bounds;
+  CGFloat W = b.size.width, H = b.size.height;
+  double t = self.t;
+
+  // Empty: a single dim logo so an idle screen still reads as "Claude Pets".
+  if (self.waiting.count == 0 && self.working.count == 0) {
+    CGFloat s = 140;
+    [self drawImage:self.grayLogo
+             inRect:NSMakeRect((W - s) / 2, (H - s) / 2, s, s)
+              alpha:0.22];
+    return;
+  }
+
+  // Working bots: grey, vertical column centered on the left edge, vibrating.
+  NSUInteger m = self.working.count;
+  if (m > 0) {
+    CGFloat total = m * kWorkSize + (m - 1) * kGap;
+    CGFloat topY = (H + total) / 2 - kWorkSize; // top slot's origin-y
+    for (NSUInteger i = 0; i < m; i++) {
+      double phase = i * 0.9;
+      CGFloat vx = kVibAmpl * sin(t * (2 * M_PI / kVibPeriod) + phase);
+      CGFloat vy = kVibAmpl * sin(t * (2 * M_PI / kVibPeriod) * 1.7 + phase);
+      CGFloat x = kLeftMargin + vx;
+      CGFloat y = topY - i * (kWorkSize + kGap) + vy;
+      [self drawImage:self.grayLogo
+               inRect:NSMakeRect(x, y, kWorkSize, kWorkSize)
+                alpha:1.0];
+    }
+  }
+
+  // Waiting bots: orange, horizontal row centered near the top, bobbing.
+  NSUInteger n = self.waiting.count;
+  if (n > 0) {
+    CGFloat total = n * kWaitSize + (n - 1) * kGap;
+    CGFloat startX = (W - total) / 2;
+    CGFloat baseY = H - kTopMargin - kWaitSize;
+    for (NSUInteger i = 0; i < n; i++) {
+      double phase = i * 0.7;
+      CGFloat bob = kBobAmpl * sin(t * (2 * M_PI / kBobPeriod) + phase);
+      CGFloat x = startX + i * (kWaitSize + kGap);
+      CGFloat y = baseY - bob;
+      [self drawImage:self.colorLogo
+               inRect:NSMakeRect(x, y, kWaitSize, kWaitSize)
+                alpha:1.0];
+      [self drawLabel:[self labelFor:self.waiting[i]]
+           centeredAt:x + kWaitSize / 2
+                  top:y
+                width:kWaitSize];
+    }
+  }
+}
+
+- (void)animateOneFrame {
+  self.t += [self animationTimeInterval];
+  self.frameCount += 1;
+  if (self.frameCount % kReloadFrames == 0) {
+    [self reloadSessions];
+  }
+  [self setNeedsDisplay:YES];
+}
+
+@end

--- a/configs/screensaver/default.nix
+++ b/configs/screensaver/default.nix
@@ -1,0 +1,56 @@
+{ lib, pkgs, ... }:
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+
+  # Build the ClaudePets.saver bundle: an ObjC ScreenSaverView (claude-pets.m)
+  # compiled against Cocoa + ScreenSaver, plus the two bot logos shared with the
+  # Hammerspoon overlay (configs/hammerspoon). Code signing is deferred to the
+  # activation step below, where the system codesign signs the copy in place.
+  claudePetsSaver = pkgs.stdenv.mkDerivation {
+    pname = "claude-pets-screensaver";
+    version = "1.0";
+    dontUnpack = true;
+
+    buildPhase = ''
+      runHook preBuild
+      clang -bundle -fobjc-arc -mmacosx-version-min=12.0 \
+        -framework Cocoa -framework ScreenSaver -framework Foundation \
+        -o ClaudePets ${./claude-pets.m}
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      c="$out/ClaudePets.saver/Contents"
+      mkdir -p "$c/MacOS" "$c/Resources"
+      cp ClaudePets "$c/MacOS/ClaudePets"
+      cp ${./Info.plist} "$c/Info.plist"
+      cp ${../hammerspoon/claudecode-color.png} "$c/Resources/claudecode-color.png"
+      cp ${../hammerspoon/claudecode-gray.png} "$c/Resources/claudecode-gray.png"
+      runHook postInstall
+    '';
+  };
+in
+# Darwin-only: a .saver is a macOS bundle. On NixOS this module is a no-op.
+lib.mkIf isDarwin {
+  # Install + sign the saver into ~/Library/Screen Savers on every activation.
+  # We re-copy (not symlink) because the sandboxed legacyScreenSaver host loads
+  # bundles from the user's Library, not /nix/store; chmod +w lets the system
+  # codesign re-sign the store's read-only copy in place (arm64 refuses to load
+  # an unsigned bundle).
+  #
+  # NOT automated: selecting it as the *active* screensaver. macOS 26 only
+  # registers a freshly-dropped .saver for selection once the Screen Saver
+  # settings pane has scanned it, with no headless trigger — so enabling it is a
+  # one-time manual click (System Settings > Screen Saver > ClaudePets). It then
+  # persists across reboots and rebuilds (the bundle updates in place).
+  home.activation.installClaudePetsScreensaver =
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      saver="$HOME/Library/Screen Savers/ClaudePets.saver"
+      $DRY_RUN_CMD mkdir -p "$HOME/Library/Screen Savers"
+      $DRY_RUN_CMD rm -rf "$saver"
+      $DRY_RUN_CMD cp -R ${claudePetsSaver}/ClaudePets.saver "$saver"
+      $DRY_RUN_CMD chmod -R u+w "$saver"
+      $DRY_RUN_CMD /usr/bin/codesign --force --sign - "$saver" 2>/dev/null || true
+    '';
+}

--- a/configs/screensaver/default.nix
+++ b/configs/screensaver/default.nix
@@ -33,11 +33,17 @@ let
 in
 # Darwin-only: a .saver is a macOS bundle. On NixOS this module is a no-op.
 lib.mkIf isDarwin {
-  # Install + sign the saver into ~/Library/Screen Savers on every activation.
-  # We re-copy (not symlink) because the sandboxed legacyScreenSaver host loads
-  # bundles from the user's Library, not /nix/store; chmod +w lets the system
-  # codesign re-sign the store's read-only copy in place (arm64 refuses to load
-  # an unsigned bundle).
+  # Install the saver into ~/Library/Screen Savers, but only when the built
+  # bundle actually changes: the Nix store path is a perfect change token, so a
+  # routine `darwin-rebuild switch` is a true no-op here — no re-copy, no re-sign.
+  #
+  # We copy (not symlink via home.file) and sign in place because the bundle Nix
+  # produces is not a validly signed *bundle*: only the Mach-O is linker-signed,
+  # with no sealed _CodeSignature, so `codesign --verify` on the store path fails
+  # ("code has no resources but signature indicates they must be present"). Full
+  # bundle signing needs the system codesign, which a hermetic Nix build can't
+  # run (and sigtool only signs Mach-O, not bundle resources). arm64 won't load
+  # an unsealed bundle, so we seal it here — which requires a writable copy.
   #
   # NOT automated: selecting it as the *active* screensaver. macOS 26 only
   # registers a freshly-dropped .saver for selection once the Screen Saver
@@ -46,11 +52,16 @@ lib.mkIf isDarwin {
   # persists across reboots and rebuilds (the bundle updates in place).
   home.activation.installClaudePetsScreensaver =
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      saver="$HOME/Library/Screen Savers/ClaudePets.saver"
-      $DRY_RUN_CMD mkdir -p "$HOME/Library/Screen Savers"
-      $DRY_RUN_CMD rm -rf "$saver"
-      $DRY_RUN_CMD cp -R ${claudePetsSaver}/ClaudePets.saver "$saver"
-      $DRY_RUN_CMD chmod -R u+w "$saver"
-      $DRY_RUN_CMD /usr/bin/codesign --force --sign - "$saver" 2>/dev/null || true
+      src="${claudePetsSaver}/ClaudePets.saver"
+      dest="$HOME/Library/Screen Savers/ClaudePets.saver"
+      stamp="$HOME/Library/Screen Savers/.ClaudePets.nix-source"
+      if [ ! -e "$dest" ] || [ "$(cat "$stamp" 2>/dev/null)" != "$src" ]; then
+        $DRY_RUN_CMD mkdir -p "$HOME/Library/Screen Savers"
+        $DRY_RUN_CMD rm -rf "$dest"
+        $DRY_RUN_CMD cp -R "$src" "$dest"
+        $DRY_RUN_CMD chmod -R u+w "$dest"
+        $DRY_RUN_CMD /usr/bin/codesign --force --sign - "$dest" 2>/dev/null || true
+        $DRY_RUN_CMD sh -c 'printf "%s" "$1" > "$2"' _ "$src" "$stamp"
+      fi
     '';
 }

--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -121,7 +121,6 @@ in
       "gemini-cli"
       "metalbear-co/mirrord/mirrord"
       "opencode"
-      "cue-lang/tap/cue"
       "gh"
       "yt-dlp"
       "oven-sh/bun/bun"


### PR DESCRIPTION
## Summary

The lock/idle-screen counterpart to the Hammerspoon desk-pet overlay (#72, #75). A native macOS screen saver that renders the **same two squads** of Claude Code bots, off the **same `~/.cache/claude-sessions` registry**:

- **Orange "waiting" bots** across the top — sessions needing you (`attention`/`asking`), bobbing gently.
- **Grey "working" bots** down the left edge — sessions currently `working`, vibrating gently.
- A dim centered logo when there are no active sessions, so an idle screen still reads as "Claude Pets".

So when the Mac goes idle, a glance tells you which Claudes are working and which need you — without unlocking.

## How it works

- **`configs/screensaver/claude-pets.m`** — an ObjC `ScreenSaverView`. It runs inside the **sandboxed `legacyScreenSaver` host**, whose `NSHomeDirectory()` is a redirected container — so it resolves the real home via `getpwuid()` and reads the registry by absolute path. (The host carries broad file entitlements; I verified it can read `~/.cache/claude-sessions` directly — no state mirror needed.) It parses + TTL-filters the session JSON and animates both squads.
- **`configs/screensaver/default.nix`** — a `stdenv.mkDerivation` that compiles the saver against `Cocoa` + `ScreenSaver` and bundles the two logos shared with `configs/hammerspoon`, plus a home-manager activation that copies + ad-hoc-signs it into `~/Library/Screen Savers/`. It's a re-copy (not a symlink) because the sandboxed host loads bundles from the user's Library, not `/nix/store`.

## Automated vs. manual

| Step | Automated on `darwin-rebuild switch`? |
|---|---|
| Build the `.saver` | ✅ nix derivation |
| Install + sign | ✅ home-manager activation |
| Read live sessions | ✅ direct `~/.cache` read |
| **Select as the active screensaver** | ❌ one-time manual click |

macOS 26 only registers a freshly-dropped `.saver` for selection after the Screen Saver settings pane scans it, with no headless trigger (confirmed: clearing every WallpaperAgent cache + restarting the agents still won't register it, and AppleScript `set current screen saver` fails until it's registered). So enabling is a one-time **System Settings → Screen Saver → ClaudePets** click — it then persists across reboots and rebuilds (the bundle updates in place). Documented in the module so it's not mistaken for a bug.

## Verified

- Darwin builds; the saver derivation compiles + links `ScreenSaver.framework` in the nix sandbox; the result is a valid arm64 `.saver` (logos + Info.plist + signed binary).
- An identical scratchpad build, installed + signed the same way, ran as the live screensaver and read all sessions from the registry (the sandbox-readability probe that motivated the `getpwuid` approach).
- NixOS still evaluates (the module no-ops on Linux).

## Apply

```
sudo nix run nix-darwin/nix-darwin-25.11#darwin-rebuild -- switch --flake .
```

Then **once**: System Settings → Screen Saver → pick **ClaudePets**. Have a couple of sessions working plus one waiting to see both squads at idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
