### PR TITLE
Add mullvad-vpn to Homebrew casks

### DIFF
--- a/hosts/trueswiftie/software.nix
+++ b/hosts/trueswiftie/software.nix
@@ -156,6 +156,7 @@ in
       "spotify"
       "sublime-text"
       "bitwarden"
+      "mullvad-vpn"
       "google-earth-pro"
       "calibre"
       "hiddenbar"


### PR DESCRIPTION
## Summary

Add the Mullvad VPN client (`mullvad-vpn` cask) to `hosts/trueswiftie/software.nix`, grouped next to `bitwarden`.

## Verified

- `mullvad-vpn` is a valid cask token (Mullvad VPN 2026.3).
- `nixpkgs-fmt` clean; the darwin system builds (the `Brewfile` regenerates with the new cask).

## Apply

```
sudo nix run nix-darwin/nix-darwin-25.11#darwin-rebuild -- switch --flake .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)