### PR TITLE
Add lyric-prototype MCP server (~/work)

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -470,6 +470,23 @@ let
               "mcp"
             ];
           };
+          # Lyric Prototype platform (https://prototype.lyric.tech/mcp): a remote
+          # HTTP MCP server bridged to stdio via mcp-remote (like
+          # android-remote-control above). The scoped bearer key is read from
+          # pass at launch and passed as an Authorization header, so it never
+          # lands in .mcp.json — same approach as the grafana entries. Mint the
+          # key under Prototype > Developer Tools, then create the pass entry:
+          #   pass insert api-keys/lyric-prototype
+          lyric-prototype = {
+            command = "bash";
+            args = [
+              "-c"
+              ''
+                exec npx -y mcp-remote@latest https://prototype.lyric.tech/mcp \
+                  --header "Authorization: Bearer $(pass show api-keys/lyric-prototype)"
+              ''
+            ];
+          };
         };
       }
     ];


### PR DESCRIPTION
## Summary

Add **`lyric-prototype`** — Lyric's Prototype platform MCP server (`https://prototype.lyric.tech/mcp`) — to the `~/work` project-local MCP profile (`configs/claude/default.nix`).

## How

It's a remote HTTP MCP server, so it's bridged to stdio with `mcp-remote` (mirroring the existing `android-remote-control` entry), and the scoped bearer key is read from `pass` **at launch** inside a `bash -c` wrapper (mirroring the `google-maps`/grafana entries). The key is sent as an `Authorization: Bearer …` header and **never written into `~/work/.mcp.json`**.

```nix
lyric-prototype = {
  command = "bash";
  args = [ "-c" ''
    exec npx -y mcp-remote@latest https://prototype.lyric.tech/mcp \
      --header "Authorization: Bearer $(pass show api-keys/lyric-prototype)"
  '' ];
};
```

## Before it works — create the pass entry

Mint a scoped key under **Prototype → Developer Tools**, then:

```
pass insert api-keys/lyric-prototype
```

(paste the key). Until that entry exists, only this server fails to start — nothing else is affected.

## Verified

- `nixpkgs-fmt` clean; the darwin system builds.
- Rendered the generated `~/work/.mcp.json` wiring: the endpoint and the `pass show api-keys/lyric-prototype` reference are present, and **no literal token is baked** anywhere — the secret stays a pass reference resolved at launch.

## Apply

```
sudo nix run nix-darwin/nix-darwin-25.11#darwin-rebuild -- switch --flake .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
