### PR TITLE
Add festie host — a lean Linux home profile for the agentfest container

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,3 +18,5 @@ jobs:
       run: nix eval --raw .#nixosConfigurations.ninezeroes.config.system.build.toplevel
     - name: Darwin Configuration Evaluation Check
       run: nix eval --raw .#darwinConfigurations.trueswiftie.system
+    - name: Home Configuration Evaluation Check (festie container)
+      run: nix eval --raw .#homeConfigurations.festie.activationPackage

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Nix is my way of setting up and managing my computers. It's an entirely declarat
 
 - **ninezeroes** — NixOS (x86_64-linux)
 - **trueswiftie** — macOS (aarch64-darwin)
+- **festie** — standalone home-manager (x86_64-linux), for the agentfest container
 
 ## How to navigate
 
@@ -31,6 +32,9 @@ sudo nixos-rebuild switch --flake .#ninezeroes
 
 # macOS
 sudo nix run nix-darwin/nix-darwin-25.11#darwin-rebuild -- switch --flake .
+
+# the festie container (no system to rebuild, just activate the home profile)
+nix run home-manager/master -- switch --flake .#festie
 ```
 
 ## What else

--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -5,10 +5,22 @@
 }:
 let
   homeDir = config.home.homeDirectory;
+
+  # Where the real Claude Code lives, before the wrapper below layers
+  # hierarchical skills on top. On macOS this stays the Homebrew install, which
+  # updates itself out of band on purpose. Linux (ninezeroes, and the festie
+  # container) has no Homebrew, so it gets the Nix-provided build — pinned by
+  # flake.lock, so bumping it is a lockfile bump. CLAUDE_REAL_BINARY still wins
+  # over both.
+  defaultClaudeBinary =
+    if pkgs.stdenv.isDarwin
+    then "/opt/homebrew/bin/claude"
+    else "${pkgs.claude-code}/bin/claude";
+
   claudeWrapperScript = ''
     set -euo pipefail
 
-    REAL_CLAUDE="''${CLAUDE_REAL_BINARY:-/opt/homebrew/bin/claude}"
+    REAL_CLAUDE="''${CLAUDE_REAL_BINARY:-${defaultClaudeBinary}}"
 
     case "''${1:-}" in
       -h | --help | -v | --version | auth | auto-mode | doctor | install | mcp | plugin | plugins | setup-token | update | upgrade)
@@ -493,7 +505,10 @@ let
   };
 in
 {
-  home.packages = lib.optionals pkgs.stdenv.isDarwin [
+  # Only the wrapper goes on PATH as `claude`; the real binary is referenced by
+  # absolute store path from inside it, which keeps it in the closure without
+  # two derivations fighting over bin/claude.
+  home.packages = [
     claudeWrapper
   ];
 
@@ -510,7 +525,7 @@ in
 
   # Install Claude Code plugins declaratively
   home.activation.installClaudePlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    CLAUDE="/opt/homebrew/bin/claude"
+    CLAUDE="${defaultClaudeBinary}"
     if [ -x "$CLAUDE" ]; then
       ${lib.concatMapStringsSep "\n      " (m: ''
         $CLAUDE plugin marketplace add ${m} 2>/dev/null || true

--- a/flake.nix
+++ b/flake.nix
@@ -81,9 +81,30 @@
         };
       };
 
+      # starting point of a standalone home-manager profile with no system
+      # underneath it — festie is the agentfest container, where the whole
+      # "machine" is one home directory on a persistent volume. Deliberately
+      # not a nixosConfiguration: there is no hardware to describe and no
+      # systemd to run, just the activation package baked into an OCI image.
+      homeConfigurations = {
+        festie = home-manager.lib.homeManagerConfiguration {
+          # claude-code is unfree, and allowUnfree is a nixpkgs *module* option
+          # that the other two hosts set in their configuration.nix. A
+          # standalone home-manager config has no such module, so pkgs has to
+          # be instantiated with it here.
+          pkgs = import nixpkgs {
+            system = "x86_64-linux";
+            config.allowUnfree = true;
+          };
+          extraSpecialArgs = { inherit user inputs self; };
+          modules = [ ./hosts/festie/home.nix ];
+        };
+      };
+
       checks = {
         x86_64-linux = {
           nixos = self.nixosConfigurations.ninezeroes.config.system.build.toplevel;
+          festie = self.homeConfigurations.festie.activationPackage;
         };
         aarch64-darwin = {
           darwin = self.darwinConfigurations.trueswiftie.system;

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -1,0 +1,109 @@
+{ config, pkgs, user, ... }: {
+
+  imports = [
+    ../../configs
+  ];
+
+  home = {
+    stateVersion = "23.05";
+    username = user.username;
+    homeDirectory = "/home/${user.username}";
+
+    # Host-level packages, deliberately CLI-only. festie is a container, so
+    # there is no base system underneath it and nothing that could render a
+    # GUI — everything graphical that ninezeroes carries (kitty, vscode,
+    # chrome, spotify, vlc, krita, ...) is intentionally absent, as is
+    # texliveFull. The image has to stay small enough to pull onto the homelab
+    # quickly, and every one of these has to justify its closure.
+    packages = with pkgs; [
+      # core userland — a Nix container ships with none of this
+      coreutils
+      findutils
+      diffutils
+      gnugrep
+      gnused
+      gawk
+      gnutar
+      gzip
+      which
+      less
+      procps
+      zip
+      unzip
+      # TLS trust store; the image entrypoint points SSL_CERT_FILE at this
+      cacert
+
+      # version control (git and tmux themselves come from ../../configs)
+      gh
+      git-lfs
+      difftastic
+
+      # search & navigation
+      ripgrep
+      fd
+      fzf
+      tree
+
+      # data wrangling
+      jq
+      yq
+
+      # network
+      curl
+      wget
+      openssh
+      openssl
+      inetutils # telnet, ping, ...
+      bind # dig, ...
+
+      # cloud & kubernetes. Only AWS for now — gcloud and azure-cli are each
+      # roughly a gigabyte, so they get added the day something actually needs
+      # them rather than on the off chance.
+      awscli2
+      kubectl
+      kubernetes-helm
+      kustomize
+
+      # languages & runtimes
+      python3
+      nodejs
+      go
+
+      # misc dev
+      shellcheck
+      nixpkgs-fmt
+      sqlite
+
+      # secrets — configs/pass and configs/gopass expect these to exist
+      gnupg
+      gopass
+      passExtensions.pass-update
+    ];
+  };
+
+  programs = {
+    home-manager = {
+      enable = true;
+    };
+
+    htop = {
+      enable = true;
+      settings.color_scheme = 6;
+    };
+
+    password-store = {
+      enable = true;
+    };
+
+    # Carried over from the laptop verbatim, so the agent gets the same skills
+    # it has locally. Note that this makes container startup depend on an SSH
+    # key that can read the agent-smith repo: the sync runs as a home-manager
+    # activation step and `git clone` there is not fault-tolerant, so a missing
+    # key fails activation rather than degrading. Flip to false for a first
+    # smoke test if the key isn't mounted yet.
+    claude-skills = {
+      enablePrivate = true;
+      privateRepo.url = "git@github.com:rounakdatta/agent-smith.git";
+    };
+  };
+}


### PR DESCRIPTION
`festie` is a third host: the "one deployment = one computer" container that [agentfest](https://github.com/rounakdatta/agentfest) will run on the homelab, with Codeman and Claude Code layered on top of a single persistent volume.

It is deliberately **a standalone `homeConfiguration`, not a `nixosConfiguration`** — there is no hardware to describe and no systemd to run, just an activation package to bake into an OCI image. That's the one new pattern here; the rest is reuse.

## Reuse is the whole point

`hosts/festie/home.nix` imports `../../configs` wholesale, so vim, tmux, fish, git, ssh, atuin, claude and claude-skills carry over from the laptop unchanged. The macOS-only modules (`hammerspoon`, `screensaver`, `nextcloud`) are already `isDarwin`-guarded, so **nothing had to be refactored** to make this work.

The weight that made `ninezeroes` unsuitable as a container base was never in `configs/` — it was that host's own package list (chrome, vscode, spotify, vlc, krita, zoom, `texliveFull`, ...). festie simply doesn't import it and declares its own CLI-only list instead.

On cloud CLIs: only `awscli2` for now. `gcloud` and `azure-cli` are roughly a gigabyte each, so they get added the day something actually needs them.

## configs/claude had to grow a Linux path

Two things hardcoded `/opt/homebrew/bin/claude` — the wrapper's `CLAUDE_REAL_BINARY` default and the plugin-install activation — and the wrapper itself was gated behind `isDarwin`. **`ninezeroes` has therefore been getting `settings.json` and the MCP merge but neither the hierarchical-skills wrapper nor any plugins**; this fixes that too, incidentally.

Both now resolve through a single `defaultClaudeBinary` binding: Homebrew on Darwin (self-updating, behaviour unchanged), `pkgs.claude-code` elsewhere — pinned by `flake.lock`, so bumping it is a lockfile bump.

Only the wrapper goes on `PATH` as `claude`; the real binary is referenced by absolute store path from inside it, so the two derivations never collide over `bin/claude`.

## One non-obvious bit

`claude-code` is unfree, and `allowUnfree` is a nixpkgs *module* option that the other two hosts set in their `configuration.nix`. A standalone home-manager config has no such module, so festie instantiates `pkgs` with it explicitly.

## Verification

All three configurations evaluate, and `nixpkgs-fmt --check` is clean:

| config | result |
|---|---|
| `homeConfigurations.festie.activationPackage` | ✅ `…-home-manager-generation` |
| `nixosConfigurations.ninezeroes` | ✅ `…-nixos-system-ninezeroes-26.05…` |
| `darwinConfigurations.trueswiftie` | ✅ `…-darwin-system-26.05…` |

CI gains a matching eval check for festie.

Closure size is **not** measured — x86_64-linux paths can't be realised on the Mac this was built from. The first image build will tell us, and that's the number that decides whether the package list needs trimming further.

## Before deploying this

`claude-skills.enablePrivate` is on, so the agent gets the same skills it has locally. Its `agent-smith` `git clone` runs as an activation step **with no fault tolerance**, so the container needs an SSH key that can read that repo or activation fails outright rather than degrading. Flip it to `false` for a first smoke test if the key isn't wired up yet — or, separately, it might be worth making that clone tolerant of a missing key so a network blip can't wedge a `home-manager switch` on the laptop either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)