### PR TITLE
Make Doom Emacs opt-out, and turn it off for festie

### DIFF
--- a/configs/emacs/default.nix
+++ b/configs/emacs/default.nix
@@ -1,51 +1,73 @@
-{ config, pkgs, ... }: {
-  programs.emacs = {
-    enable = true;
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.programs.doomEmacs;
+in
+{
+  options.programs.doomEmacs = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to install Emacs and bootstrap Doom.
+
+        On by default, because on a laptop this is simply part of the setup.
+        Worth turning off for headless hosts: the first activation on a fresh
+        home clones and byte-compiles well over a hundred packages, and since
+        activation runs before anything else on that machine can start, it
+        blocks the boot for as long as it takes.
+      '';
+    };
   };
 
-  home.file.".doom.d/init.el".text = builtins.readFile ./init.el;
-  home.file.".doom.d/config.el".text = builtins.readFile ./config.el;
-  home.file.".doom.d/packages.el".text = builtins.readFile ./packages.el;
+  config = lib.mkIf cfg.enable {
+    programs.emacs = {
+      enable = true;
+    };
 
-  # Doom Emacs setup is now idempotent and non-interactive for stable rebuilds
-  # https://github.com/doomemacs/doomemacs/issues/5918#issuecomment-1028588770
-  home.activation = {
-    doomEmacs = ''
-      DOOM="$HOME/.emacs.d"
-      DOOM_INSTALLED_MARKER="$DOOM/.nix-doom-installed"
+    home.file.".doom.d/init.el".text = builtins.readFile ./init.el;
+    home.file.".doom.d/config.el".text = builtins.readFile ./config.el;
+    home.file.".doom.d/packages.el".text = builtins.readFile ./packages.el;
 
-      # Only run full setup if Doom is not already installed
-      if [ ! -f "$DOOM_INSTALLED_MARKER" ]; then
-        echo "Installing Doom Emacs for the first time..."
+    # Doom Emacs setup is now idempotent and non-interactive for stable rebuilds
+    # https://github.com/doomemacs/doomemacs/issues/5918#issuecomment-1028588770
+    home.activation = {
+      doomEmacs = ''
+        DOOM="$HOME/.emacs.d"
+        DOOM_INSTALLED_MARKER="$DOOM/.nix-doom-installed"
 
-        if [ ! -d "$DOOM" ]; then
-            mkdir -p "$DOOM"
-        fi
-        cd $DOOM
+        # Only run full setup if Doom is not already installed
+        if [ ! -f "$DOOM_INSTALLED_MARKER" ]; then
+          echo "Installing Doom Emacs for the first time..."
 
-        # the following PATH addition is to make sure that binaries like `git`, `emacs` are available for use
-        export PATH="${config.home.path}/bin:$PATH"
+          if [ ! -d "$DOOM" ]; then
+              mkdir -p "$DOOM"
+          fi
+          cd $DOOM
 
-        git init
-        if git remote | grep -q origin; then
-            git remote set-url origin https://github.com/doomemacs/doomemacs.git
+          # the following PATH addition is to make sure that binaries like `git`, `emacs` are available for use
+          export PATH="${config.home.path}/bin:$PATH"
+
+          git init
+          if git remote | grep -q origin; then
+              git remote set-url origin https://github.com/doomemacs/doomemacs.git
+          else
+              git remote add origin https://github.com/doomemacs/doomemacs.git
+          fi
+
+          git fetch origin
+          git pull origin master
+
+          # the bash-subcommanding is done to avoid https://github.com/doomemacs/doomemacs/issues/4181#issuecomment-729741088
+          bash -c "yes | $DOOM/bin/doom install"
+
+          # Mark as installed to avoid re-running on every rebuild
+          touch "$DOOM_INSTALLED_MARKER"
+          echo "Doom Emacs installation complete. Run 'doom sync' manually if needed."
         else
-            git remote add origin https://github.com/doomemacs/doomemacs.git
+          echo "Doom Emacs already installed. Skipping setup."
+          echo "To sync packages, run: ~/.emacs.d/bin/doom sync"
         fi
-
-        git fetch origin
-        git pull origin master
-
-        # the bash-subcommanding is done to avoid https://github.com/doomemacs/doomemacs/issues/4181#issuecomment-729741088
-        bash -c "yes | $DOOM/bin/doom install"
-
-        # Mark as installed to avoid re-running on every rebuild
-        touch "$DOOM_INSTALLED_MARKER"
-        echo "Doom Emacs installation complete. Run 'doom sync' manually if needed."
-      else
-        echo "Doom Emacs already installed. Skipping setup."
-        echo "To sync packages, run: ~/.emacs.d/bin/doom sync"
-      fi
-    '';
+      '';
+    };
   };
 }

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -86,6 +86,14 @@
       enable = true;
     };
 
+    # No editor bootstrap on a headless box. Doom's first-run install clones
+    # and byte-compiles well over a hundred packages, and because activation
+    # gates the container's startup, that delay lands squarely between a fresh
+    # volume and a usable terminal. Nothing here is going to open Emacs.
+    doomEmacs = {
+      enable = false;
+    };
+
     htop = {
       enable = true;
       settings.color_scheme = 6;


### PR DESCRIPTION
festie is headless and driven by Claude Code — nothing on it is ever going to open Emacs.

More to the point: Doom's first-run install clones and byte-compiles **well over a hundred packages**, and because home-manager activation gates the container's startup, that delay sits squarely between a fresh volume and a usable terminal. Observed on the real deploy — the pod spent minutes cloning `vertico`, `consult`, `embark`, `flycheck` and friends before anything else could happen.

`configs/emacs` grows a proper `programs.doomEmacs.enable` option defaulting to `true`, and `hosts/festie` sets it to `false`.

## Verification

The existing hosts are provably untouched — both evaluate to **byte-identical store paths** before and after:

| host | store path |
|---|---|
| `ninezeroes` | `fd2zhrjrm0cvb5535d8avy8s8jskpps0-nixos-system-ninezeroes-26.05…` |
| `trueswiftie` | `d1aglmxxw9hkym5j0lp16m6m5m5a4kv6-darwin-system-26.05…` |

`homeConfigurations.festie` evaluates, and `nixpkgs-fmt --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)