### PR TITLE
Make festie's gpg-agent usable without a display

### DIFF
--- a/configs/gnupg/default.nix
+++ b/configs/gnupg/default.nix
@@ -12,8 +12,11 @@ in
 
   services.gpg-agent = {
     enable = true;
-    pinentry.package = if isDarwin then pkgs.pinentry_mac else pkgs.pinentry-gnome3;
-    enableSshSupport = !isDarwin;
+    # mkDefault so a headless host can swap these out. Both defaults assume a
+    # graphical session with a systemd user bus behind it, which is exactly
+    # what a container does not have.
+    pinentry.package = lib.mkDefault (if isDarwin then pkgs.pinentry_mac else pkgs.pinentry-gnome3);
+    enableSshSupport = lib.mkDefault (!isDarwin);
   };
 
   # GPG Suite (brew) ships gpg-agent 2.2.41 and auto-starts it, while nix's gpg

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -81,6 +81,30 @@
     ];
   };
 
+  # The GPG key is passphrase-protected, and on a headless box that is the
+  # difference between pass/gopass working and silently failing — including the
+  # MCP servers that shell out to `pass show`.
+  services.gpg-agent = {
+    # pinentry-gnome3 has no display to draw on here, so the first decryption
+    # would fail with no way to prompt. curses draws inside whatever tty is
+    # asking, which is the tmux pane Codeman hands you.
+    pinentry.package = pkgs.pinentry-curses;
+
+    # Unlock once per container, not once every ten minutes. This machine is
+    # meant to keep working while nobody is watching it, and a cache that
+    # expires mid-run turns into an agent stuck on an invisible prompt.
+    # 400 days; the practical lifetime is the pod's, since ~/.gnupg's agent
+    # dies with it.
+    defaultCacheTtl = 34560000;
+    maxCacheTtl = 34560000;
+
+    # No systemd user session in a container, so the agent's ssh socket never
+    # comes up. ssh uses the explicit IdentityFile from configs/ssh instead,
+    # and pointing SSH_AUTH_SOCK at a socket that will never exist only
+    # produces confusing failures.
+    enableSshSupport = false;
+  };
+
   programs = {
     home-manager = {
       enable = true;


### PR DESCRIPTION
The GPG key is passphrase-protected, so `pass`/`gopass` — and the MCP servers that shell out to `pass show` — can't decrypt anything until the passphrase is entered once.

On festie that could **never** happen: `configs/gnupg` selects `pinentry-gnome3` on Linux, which has no display to draw on in a container. The prompt had nowhere to appear, so decryption would just fail.

## Changes

- **`pinentry-curses`** for festie — draws inside whatever tty is asking, which is the tmux pane Codeman already gives you.
- **Cache TTLs to 400 days**, making it a genuine one-time unlock per container rather than every 10 minutes. A cache that expires mid-run leaves an unattended agent stuck on a prompt nobody is there to answer, which defeats the point of the machine.
- **`enableSshSupport = false`** on festie. home-manager wires gpg-agent's ssh support through a systemd user service, and a container has no user session — so `SSH_AUTH_SOCK` would point at a socket that never appears. `configs/ssh` names an explicit `IdentityFile` anyway.
- `configs/gnupg`'s two defaults become `lib.mkDefault` so a host can override them at all.

## Verification

Existing hosts evaluate to **byte-identical store paths**, so `mkDefault` changed nothing for them:

| host | store path |
|---|---|
| `ninezeroes` | `fd2zhrjrm0cvb5535d8avy8s8jskpps0-nixos-system-ninezeroes-26.05…` |
| `trueswiftie` | `d1aglmxxw9hkym5j0lp16m6m5m5a4kv6-darwin-system-26.05…` |

`homeConfigurations.festie` evaluates; `nixpkgs-fmt --check` clean.

## Usage

After this, the first `pass show` in a Codeman terminal prompts in-pane for the passphrase; everything afterwards is cached for the life of the pod.

If you'd rather it not need a human at all after a restart — which is arguably the right call for a box meant to run unattended — the alternative is `gpg-preset-passphrase` with the passphrase itself in Bitwarden. That trades the passphrase's value away (it would sit next to the key in the same Secret), so I didn't assume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)