### PR TITLE
Add atuin to festie

### DIFF
--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -44,6 +44,12 @@
       fzf
       tree
 
+      # configs/fish runs `atuin init fish` at startup and configs/atuin
+      # restores its sync key, but neither installs the binary — ninezeroes
+      # happens to carry it in its own host list, so the dependency is easy to
+      # miss until every shell opens with "Unknown command: atuin".
+      atuin
+
       # data wrangling
       jq
       yq


### PR DESCRIPTION
Every shell on festie opens with:

```
fish: Unknown command: atuin
~/.config/fish/config.fish (line 73):
    atuin init fish --disable-up-arrow | source
```

`configs/fish` initialises atuin at startup and `configs/atuin` restores its sync key from `pass` — but **neither installs the binary**. `ninezeroes` happens to carry `atuin` in its own host package list, so nothing in `configs/` ever had to declare the dependency.

festie's package list was written from scratch and didn't include it. Classic third-host gap: a dependency that was implicitly satisfied everywhere it had been used before.

Verified: `homeConfigurations.festie` evaluates, `nixpkgs-fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)