### PR TITLE
Sync the password store from the remote's default branch

### DIFF
--- a/configs/pass/default.nix
+++ b/configs/pass/default.nix
@@ -33,7 +33,16 @@ in
         # BatchMode/accept-new so activation can't stall on an SSH host-key or
         # passphrase prompt; point at the manual command rather than guessing why
         export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
-        if ! { git fetch origin && git pull origin master; } >/dev/null 2>&1; then
+        # Follow whatever the remote calls its default branch instead of
+        # assuming master. The store moved to main long ago, and a hardcoded
+        # master silently bootstraps a fresh machine from a branch that is
+        # hundreds of commits stale — which looks like "pass works" right up
+        # until a credential turns out to be the old one.
+        DEFAULT_BRANCH="$(git ls-remote --symref origin HEAD 2>/dev/null \
+          | awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }')"
+        [ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH=main
+
+        if ! { git fetch origin && git pull origin "$DEFAULT_BRANCH"; } >/dev/null 2>&1; then
             echo "note: password-store not synced; run 'git -C $PW_DIR pull' once gitlab access is set up"
         fi
 


### PR DESCRIPTION
`configs/pass` hardcoded `git pull origin master`. The store's remote has **both** `main` and `master`, and:

```
main is ahead of master by: 164 commits
```

So any machine bootstrapped by this activation gets a password store that's months stale.

**That's worse than an outright failure, because it looks like success.** `pass` works, entries decrypt, everything seems fine — the only symptom is that a credential turns out to be an old one.

festie hit exactly this: its `github.com/pat` was a long-revoked classic `ghp_` token, while the laptop had a current one the whole time. The laptop never noticed because its store was set up by hand tracking `main`; only a machine bootstrapped *by this code path* is affected.

## Fix

Resolve the remote's own default branch via `git ls-remote --symref origin HEAD`, falling back to `main` — so it follows the repo rather than a guess made when the module was written.

## Verification

`homeConfigurations.festie` and `darwinConfigurations.trueswiftie` both evaluate; `nixpkgs-fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)