### PR TITLE
Install mic on festie, so the deploy MCP server actually has a binary

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -15,6 +15,7 @@
     ./claude
     ./go
     ./cargo
+    ./mic
     ./claude-skills
     ./atuin
     ./hammerspoon

--- a/configs/mic/default.nix
+++ b/configs/mic/default.nix
@@ -1,0 +1,116 @@
+{ config, lib, ... }:
+
+# Lyric's `mic` CLI, installed from its GitHub releases.
+#
+# The laptop does NOT use this: trueswiftie takes mic from the lyric-tech/mic
+# tap (hosts/trueswiftie/software.nix), and a hand-installed copy in
+# ~/.local/bin would shadow the Homebrew one depending on PATH order. This
+# module exists for hosts with no Homebrew to speak of — festie, the agentfest
+# container — where mic is not optional: configs/claude declares the
+# `notprod-lyric-deploy` MCP server as `command = "mic"`, and that declaration
+# is not platform-gated, so it lands on Linux hosts too. Without mic on PATH
+# the server is declared and dead.
+#
+# mic ships statically-linked Linux binaries as of 0.7.0 (lyric-tech/mic#55),
+# which is what makes this possible at all — there is no glibc loader at
+# /lib64 in a Nix-built container.
+
+let
+  cfg = config.programs.lyric-mic;
+  binDir = "${config.home.homeDirectory}/.local/bin";
+in
+{
+  options.programs.lyric-mic = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Install the mic CLI into ~/.local/bin from lyric-tech/mic releases.
+        Leave this off wherever Homebrew already provides mic.
+      '';
+    };
+
+    version = lib.mkOption {
+      type = lib.types.str;
+      default = "latest";
+      description = ''
+        Release tag to install, or "latest" to resolve against GitHub on every
+        activation. "latest" matches how agentfest tracks claude-code and
+        codeman: the machine follows upstream by re-activating rather than by
+        editing a pin, and the marker file below means it only re-downloads
+        when upstream has actually moved.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Deliberately ahead of any Homebrew prefix on PATH. On a host that carries
+    # both (festie installs mic this way AND has brew available), this copy is
+    # the reliable one — it needs nothing but gh — so it should win by default.
+    # A brew-installed mic stays reachable at $(brew --prefix)/bin/mic for
+    # explicit testing.
+    home.sessionPath = [ binDir ];
+
+    # entryAfter writeBoundary is the same slot the go/cargo/npm package
+    # modules use — after home-manager has finished linking the generation, so
+    # gh and its config are in place.
+    home.activation.installLyricMic = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
+
+      # Every failure below is soft. This runs during container startup on
+      # festie, and activation gates whether the machine becomes usable at
+      # all — refusing to boot because GitHub was briefly unreachable would be
+      # a far worse outcome than running yesterday's mic.
+      if ! command -v gh >/dev/null 2>&1; then
+        echo "mic: gh unavailable, skipping install"
+        exit 0
+      fi
+      if ! gh auth status >/dev/null 2>&1; then
+        echo "mic: gh not authenticated (run 'gh auth login'), skipping install"
+        exit 0
+      fi
+
+      case "$(uname -s)" in
+        Linux) micOS=linux ;;
+        Darwin) micOS=darwin ;;
+        *) echo "mic: unsupported OS $(uname -s), skipping"; exit 0 ;;
+      esac
+      case "$(uname -m)" in
+        x86_64 | amd64) micArch=amd64 ;;
+        aarch64 | arm64) micArch=arm64 ;;
+        *) echo "mic: unsupported architecture $(uname -m), skipping"; exit 0 ;;
+      esac
+
+      micTarget="${cfg.version}"
+      if [ "$micTarget" = "latest" ]; then
+        micTarget="$(gh release view --repo lyric-tech/mic --json tagName -q .tagName 2>/dev/null || true)"
+        if [ -z "$micTarget" ]; then
+          echo "mic: could not resolve the latest release; keeping the current install"
+          exit 0
+        fi
+      fi
+
+      micMarker="${binDir}/.mic-version"
+      if [ "$(cat "$micMarker" 2>/dev/null || true)" = "$micTarget" ] && [ -x "${binDir}/mic" ]; then
+        echo "mic $micTarget already installed"
+        exit 0
+      fi
+
+      mkdir -p "${binDir}"
+      micTmp="$(mktemp -d)"
+      # Streamed straight out of gh into tar: the asset lives on a private
+      # repo, so a plain curl would 404 without a token. gh already holds one.
+      if gh release download "$micTarget" \
+           --repo lyric-tech/mic \
+           --pattern "mic_''${micOS}_''${micArch}.tar.gz" \
+           --output - 2>/dev/null | tar xz -C "$micTmp" mic; then
+        install -m 0755 "$micTmp/mic" "${binDir}/mic"
+        printf '%s\n' "$micTarget" > "$micMarker"
+        echo "mic: installed $micTarget"
+      else
+        echo "mic: download of $micTarget failed; leaving the existing install in place"
+      fi
+      rm -rf "$micTmp"
+    '';
+  };
+}

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -143,5 +143,14 @@
       enablePrivate = true;
       privateRepo.url = "git@github.com:rounakdatta/agent-smith.git";
     };
+
+    # configs/claude declares the notprod-lyric-deploy MCP server as
+    # `command = "mic"` for ~/work, and that block is not platform-gated — so
+    # it lands here too. Without this the server is declared and dead, which is
+    # exactly what was happening. The laptop gets mic from the lyric-tech/mic
+    # Homebrew tap instead; see configs/mic for why this host can't.
+    lyric-mic = {
+      enable = true;
+    };
   };
 }


### PR DESCRIPTION
## The bug this fixes

`configs/claude` declares the `notprod-lyric-deploy` MCP server for `~/work`:

```nix
notprod-lyric-deploy = {
  command = "mic";
  args = [ "mcp" ];
};
```

That block isn't platform-gated, and `hosts/festie/home.nix` imports `../../configs` wholesale — so it lands on festie too. But mic was macOS-only, installed from the `lyric-tech/mic` Homebrew tap (`hosts/trueswiftie/software.nix`), and festie has no Homebrew.

Checked on the running pod, not inferred:

```console
$ grep -A3 notprod-lyric-deploy ~/work/.mcp.json
    "notprod-lyric-deploy": {
      "args": [ "mcp" ],
      "command": "mic"
$ command -v mic
(nothing)
```

The server was declared and dead.

## Why it's possible now

mic 0.7.0 ([lyric-tech/mic#55](https://github.com/lyric-tech/mic/pull/55)) ships statically-linked Linux binaries. That's load-bearing, not incidental: a Nix-built image has no glibc loader at `/lib64`, so a cgo build wouldn't have executed here at all.

## What this adds

`configs/mic` — a home-manager module that installs mic from its GitHub releases into `~/.local/bin`, **defaulting to off**. festie enables it. The laptop deliberately doesn't: it already gets mic from the tap, and a second copy would shadow the Homebrew one depending on PATH order.

Choices worth reviewing rather than taking on trust:

**Downloads through `gh`, not curl.** The assets are on a private repo, so curl would 404. gh already holds a token. Streamed straight into `tar`, so nothing lands on disk half-written.

**Tracks `latest` by default,** with a marker file recording the installed tag. Same model agentfest already uses for claude-code and codeman: the machine follows upstream by re-activating, and only re-downloads when upstream actually moved. Set `programs.lyric-mic.version` to pin.

**Every failure path is soft and exits 0.** This runs during container startup, where activation gates whether the machine becomes usable at all. Refusing to boot because GitHub was briefly unreachable would be far worse than running yesterday's mic. Missing gh, unauthenticated gh, unknown OS/arch, and a failed download are all warnings.

**`~/.local/bin` goes on `home.sessionPath` ahead of any Homebrew prefix.** On a host carrying both — which festie will, once brew lands — this copy needs nothing but gh, so it should win by default. A brew-installed mic stays reachable at `$(brew --prefix)/bin/mic` for explicit testing.

## Verification

`nixpkgs-fmt --check .` clean, and all three of CI's eval checks pass locally:

| Config | Result |
|---|---|
| `homeConfigurations.festie.activationPackage` | ✅ |
| `darwinConfigurations.trueswiftie.system` | ✅ |
| `nixosConfigurations.ninezeroes.config.system.build.toplevel` | ✅ |

The last two matter because this touches `configs/default.nix`, which every host imports. The module is **provably inert** there — not merely disabled:

```
programs.lyric-mic.enable   festie true   trueswiftie false   ninezeroes false
home.activation has installLyricMic       festie true   trueswiftie false
```

And the generated activation script was extracted from the evaluated config and run for real, all three branches:

```
1) fresh install       → mic: installed 0.7.0   (mic 0.7.0, commit 8b0d90a)
2) re-run              → mic 0.7.0 already installed
3) PATH without gh     → mic: gh unavailable, skipping install   (exit 0)
```

## Follow-ups, not in this PR

- agentfest needs to bump its `dotfiles` flake input to pick this up, then ship a new image.
- Homebrew on festie is a separate change in agentfest (its shell prelude needs `grep`/`sed`/`awk` in `/bin`, which a Nix image doesn't have). That's what will let us exercise the Linux brew formula end-to-end; this PR is the durable install that shouldn't depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
