### PR TITLE
Give Linux hosts bun, so the Bash hook stops failing on every command

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -510,7 +510,22 @@ in
   # two derivations fighting over bin/claude.
   home.packages = [
     claudeWrapper
-  ];
+  ]
+  # bun, for the two things above that shell out to `bunx`: the PostToolUse
+  # Bash hook and the bash-history MCP server. trueswiftie gets bun from
+  # Homebrew ("oven-sh/bun/bun" in hosts/trueswiftie/software.nix), so it must
+  # not also get a Nix copy fighting for bin/bun — same darwin/Linux split as
+  # defaultClaudeBinary above, for the same reason.
+  #
+  # Without this on a Linux host, EVERY Bash tool call ends in
+  #
+  #   PostToolUse:Bash hook error
+  #   Failed with non-blocking status code: /bin/sh: line 1:
+  #   bunx: command not found
+  #
+  # and the bash-history server never starts at all. Non-blocking, so it only
+  # ever looked like noise — but it fired on every single command.
+  ++ lib.optional (!pkgs.stdenv.isDarwin) pkgs.bun;
 
   # Create ~/.claude directory and settings.json
   home.file.".claude/settings.json" = {


### PR DESCRIPTION
## The error

Every single Bash tool call on festie ends in:

```
PostToolUse:Bash hook error
Failed with non-blocking status code: /bin/sh: line 1: bunx: command not found
```

## Why

`configs/claude` wires up two things that shell out to `bunx`:

| Where | What |
|---|---|
| `configs/claude/default.nix:345` | `PostToolUse` / `Bash` hook — `bunx github:nitsanavni/bash-history-mcp hook` |
| `configs/claude/default.nix:380` | the `bash-history` MCP server — `command = "bunx"` |

Nothing installs bun. `trueswiftie` gets it from Homebrew (`"oven-sh/bun/bun"` in `hosts/trueswiftie/software.nix`), and Linux hosts have no equivalent — so on festie and ninezeroes `bunx` simply isn't there.

It's non-blocking, so it only ever looked like noise. But it fired on **every command**, and the `bash-history` MCP server never started at all.

## Fix

`pkgs.bun` for non-darwin only — the same split `configs/claude` already uses for `defaultClaudeBinary`, and for the same reason: trueswiftie must not get a second bun in the Nix profile fighting Homebrew's for `bin/bun`.

## Verification

- `pkgs.bun` 1.3.11 resolves for `x86_64-linux`, ships both `bun` and `bunx`, and **runs on the festie container** (`bun --version` → `1.3.11`)
- ran the exact failing command with bun on PATH:

  ```console
  $ echo "$payload" | sh -c 'bunx github:nitsanavni/bash-history-mcp hook'
  Saved lockfile
  $ echo $?
  0
  ```

  It fetches and executes rather than dying at `command not found`, and **exits 0** — so the error line disappears rather than changing shape. (Previously `exit 127`, which is what Claude Code reported as the non-blocking status code.)
- bun lands where it should and nowhere else:

  ```
  festie: true    ninezeroes: true    trueswiftie: false
  ```
- `nixpkgs-fmt --check .` clean; all three of CI's eval checks pass

## One observation, deliberately not fixed here

With `bunx` working, the hook now prints this on stderr:

```
Failed to start atuin history entry: Error: Failed to find $ATUIN_SESSION in the environment.
```

`configs/fish` runs `atuin init fish`, `configs/bash` doesn't, and Codeman gave this session `bash` (`SHELL=/bin/bash`) — so `ATUIN_SESSION` is never set. It **exits 0**, so it isn't reported as a hook error and nothing breaks. Separate concern; happy to take it in its own PR if you want bash to init atuin too.

## Sequencing

This wants to ride into the image *with* the mic change rather than after it — otherwise we deploy twice. Once merged I'll bump agentfest's dotfiles pin again, tag `v0.1.19`, re-point homelab.setup, and deploy once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
