### PR TITLE
Give festie all three cloud CLIs, because that's where mic is used

### DIFF
--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -62,10 +62,32 @@
       inetutils # telnet, ping, ...
       bind # dig, ...
 
-      # cloud & kubernetes. Only AWS for now — gcloud and azure-cli are each
-      # roughly a gigabyte, so they get added the day something actually needs
-      # them rather than on the off chance.
+      # cloud & kubernetes. All three providers, deliberately — this used to be
+      # AWS-only, on the reasoning that gcloud and azure-cli are ~1GB each and
+      # should wait for something to actually need them. mic is that something:
+      # festie is where it gets used most, and half of it is unusable without
+      # these.
+      #
+      # Concretely, `mic switch <cluster>` shells out to the provider CLI to
+      # fetch credentials — `gcloud container clusters get-credentials` for GKE,
+      # `az aks get-credentials` for AKS — so without them every GCP and Azure
+      # cluster in `mic check` can only ever show ✗, and the clusters
+      # themselves are unreachable. Roughly half of Lyric's fleet is on those
+      # two providers.
       awscli2
+      # Nix rather than the CLI's own installer: it bundles its own Python, and
+      # withExtraComponents lets the GKE auth plugin be declared instead of
+      # `gcloud components install` at activation. kubectl cannot talk to a GKE
+      # cluster without that plugin, so gcloud alone would get us a kubeconfig
+      # we couldn't use. Same form hosts/trueswiftie already uses.
+      (google-cloud-sdk.withExtraComponents [ google-cloud-sdk.components.gke-gcloud-auth-plugin ])
+      azure-cli
+      # AWS SSM, for reaching BYOC lyriclets. mic's kubeconfig fetch itself only
+      # needs the plain SSM API (send-command / get-command-invocation, no
+      # plugin), but `mic doctor` checks for this binary and an interactive
+      # `aws ssm start-session` genuinely requires it — so having it here is the
+      # difference between doctor reporting a clean bill and a permanent ○.
+      ssm-session-manager-plugin
       kubectl
       kubernetes-helm
       kustomize


### PR DESCRIPTION
## Why now

festie's package list said this out loud:

> `# cloud & kubernetes. Only AWS for now — gcloud and azure-cli are each`
> `# roughly a gigabyte, so they get added the day something actually needs`
> `# them rather than on the off chance.`

mic is that something, and this is the day. `mic switch <cluster>` shells out to the provider's own CLI for credentials — `gcloud container clusters get-credentials` for GKE, `az aks get-credentials` for AKS. Without them, **every GCP and Azure cluster in `mic check` can only ever render ✗, and none is reachable at all.** Roughly half of Lyric's fleet is on those two providers, so half of mic's cluster-facing surface was inert on the box where it gets used most.

Found the hard way rather than theorised: asked to count nydus pods on `techno` (GKE), I couldn't get kubectl access at all. `mic byoc kubeconfig techno` returns

```
404: {"error":"not_found","message":"no provisioning request found for cluster"}
```

because that endpoint only serves *provisioned lyriclets* and techno is manually registered. The only route is gcloud — which wasn't installed. (For contrast, `rounakny3` is a lyriclet, so DE hands over its kubeconfig directly and it worked fine.)

## What's added

| Package | Why |
|---|---|
| `google-cloud-sdk.withExtraComponents [ …gke-gcloud-auth-plugin ]` | Same form `hosts/trueswiftie` already uses. The plugin is **not** optional — kubectl can't authenticate to GKE without it, so plain gcloud would hand us a kubeconfig we couldn't use. |
| `azure-cli` | AKS clusters (`bliss`, `jnjdev`, and the prod Azure fleet). |
| `ssm-session-manager-plugin` | Provides the `session-manager-plugin` binary `mic doctor` checks for. |

On that last one, worth being precise: mic's *own* kubeconfig fetch only needs the plain SSM API (`send-command` / `get-command-invocation`, no plugin). But an interactive `aws ssm start-session` does require it, and without it `mic doctor` shows a ○ that can never be cleared — so this is as much about doctor telling the truth as about capability.

## The cost — measured, not estimated

```
gcloud + gke plugin    132 MiB download    831 MB unpacked
azure-cli               43 MiB download   1022 MB unpacked
ssm-session-manager-plugin                negligible
```

**~1.9 GB added to the image**, less in practice since python3 is already in the closure and shared.

That trades directly against agentfest's README goal — *"The image has to stay small enough to pull onto the homelab quickly"* — and is precisely why this was deferred originally. **Worth re-reading that line before merging** if pull time matters more to you than the capability. The alternative shapes, if so: install them at runtime into the PVC like codeman/claude-code (slower boot, less declarative), or keep festie AWS-only and reach GCP/Azure clusters from the laptop.

## Verification

- `nixpkgs-fmt --check .` clean
- all three of CI's eval checks pass:

  | Config | |
  |---|---|
  | `homeConfigurations.festie.activationPackage` | ✅ |
  | `darwinConfigurations.trueswiftie.system` | ✅ |
  | `nixosConfigurations.ninezeroes.config.system.build.toplevel` | ✅ |

- all four cloud packages resolve into festie's `home.packages`: `awscli2`, `google-cloud-sdk-552.0.0`, `azure-cli`, `ssm-session-manager-plugin`
- `gke-gcloud-auth-plugin` confirmed present in the built gcloud derivation's `bin/`
- host-only change: trueswiftie and ninezeroes untouched

## Sequencing

Same chain as before — agentfest needs a `nix flake update dotfiles`, a new tag, and a homelab pin bump before festie actually gets these. Note `0.1.21` is already published-but-undeployed, so this can ride into the same roll rather than adding another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
