### PR TITLE
Stop activation blocks from exiting the whole run

### DIFF
--- a/configs/cargo/default.nix
+++ b/configs/cargo/default.nix
@@ -27,15 +27,21 @@ in
       # to link binaries; the activation PATH doesn't include it by default.
       export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:/opt/homebrew/bin:$HOME/.cargo/bin:/usr/bin:$PATH"
 
+      # if/else rather than an early `exit`: home-manager concatenates every
+      # home.activation block into ONE bash script, so `exit` here would end the
+      # whole activation run — every step ordered after this one silently never
+      # runs. See configs/mic for the outage this actually caused.
       if ! command -v cargo >/dev/null 2>&1; then
         echo "Skipping cargo package install because cargo is unavailable"
-        exit 0
+      else
+        # Keeps the branch non-empty if this module is ever enabled with an
+        # empty package list; bash rejects an `else` with nothing in it.
+        :
+        ${lib.concatMapStringsSep "\n" (pkg: ''
+          echo "Installing ${pkg}..."
+          cargo install ${pkg} || true
+        '') cfg.packages}
       fi
-
-      ${lib.concatMapStringsSep "\n" (pkg: ''
-        echo "Installing ${pkg}..."
-        cargo install ${pkg} || true
-      '') cfg.packages}
     '';
   };
 }

--- a/configs/mic/default.nix
+++ b/configs/mic/default.nix
@@ -54,63 +54,84 @@ in
     # entryAfter writeBoundary is the same slot the go/cargo/npm package
     # modules use — after home-manager has finished linking the generation, so
     # gh and its config are in place.
+    # The whole body runs in a SUBSHELL, and that is load-bearing rather than
+    # stylistic. home-manager concatenates every home.activation block into one
+    # bash script, so a bare `exit 0` here does not "skip this module" — it ends
+    # the entire activation run, silently and with status 0. Every step ordered
+    # after this one is simply never reached: installPackages, linkGeneration,
+    # mergeGlobalMcpServers, npmPackages, restoreAtuin, syncPrivateSkills,
+    # syncClaudeDocs, writeProjectLocalMcpServers.
+    #
+    # That failure is worse than it sounds, because the early exit people
+    # actually hit is the *success* path: `mic already installed`. A fresh
+    # volume activates cleanly (mic gets downloaded, control falls through the
+    # bottom of the block), and every activation after that truncates. The
+    # machine converges exactly once and then stops, keeping ~/.claude,
+    # ~/.config/fish and ~/.config/tmux pinned to the generation that first
+    # installed mic — which on festie means dangling symlinks into a store path
+    # the next image no longer carries. Nothing logs a warning, because exiting
+    # 0 is indistinguishable from finishing.
+    #
+    # Same pattern as configs/pass, for the same reason.
     home.activation.installLyricMic = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
+      (
+        export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
 
-      # Every failure below is soft. This runs during container startup on
-      # festie, and activation gates whether the machine becomes usable at
-      # all — refusing to boot because GitHub was briefly unreachable would be
-      # a far worse outcome than running yesterday's mic.
-      if ! command -v gh >/dev/null 2>&1; then
-        echo "mic: gh unavailable, skipping install"
-        exit 0
-      fi
-      if ! gh auth status >/dev/null 2>&1; then
-        echo "mic: gh not authenticated (run 'gh auth login'), skipping install"
-        exit 0
-      fi
-
-      case "$(uname -s)" in
-        Linux) micOS=linux ;;
-        Darwin) micOS=darwin ;;
-        *) echo "mic: unsupported OS $(uname -s), skipping"; exit 0 ;;
-      esac
-      case "$(uname -m)" in
-        x86_64 | amd64) micArch=amd64 ;;
-        aarch64 | arm64) micArch=arm64 ;;
-        *) echo "mic: unsupported architecture $(uname -m), skipping"; exit 0 ;;
-      esac
-
-      micTarget="${cfg.version}"
-      if [ "$micTarget" = "latest" ]; then
-        micTarget="$(gh release view --repo lyric-tech/mic --json tagName -q .tagName 2>/dev/null || true)"
-        if [ -z "$micTarget" ]; then
-          echo "mic: could not resolve the latest release; keeping the current install"
+        # Every failure below is soft. This runs during container startup on
+        # festie, and activation gates whether the machine becomes usable at
+        # all — refusing to boot because GitHub was briefly unreachable would be
+        # a far worse outcome than running yesterday's mic.
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "mic: gh unavailable, skipping install"
           exit 0
         fi
-      fi
+        if ! gh auth status >/dev/null 2>&1; then
+          echo "mic: gh not authenticated (run 'gh auth login'), skipping install"
+          exit 0
+        fi
 
-      micMarker="${binDir}/.mic-version"
-      if [ "$(cat "$micMarker" 2>/dev/null || true)" = "$micTarget" ] && [ -x "${binDir}/mic" ]; then
-        echo "mic $micTarget already installed"
-        exit 0
-      fi
+        case "$(uname -s)" in
+          Linux) micOS=linux ;;
+          Darwin) micOS=darwin ;;
+          *) echo "mic: unsupported OS $(uname -s), skipping"; exit 0 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64 | amd64) micArch=amd64 ;;
+          aarch64 | arm64) micArch=arm64 ;;
+          *) echo "mic: unsupported architecture $(uname -m), skipping"; exit 0 ;;
+        esac
 
-      mkdir -p "${binDir}"
-      micTmp="$(mktemp -d)"
-      # Streamed straight out of gh into tar: the asset lives on a private
-      # repo, so a plain curl would 404 without a token. gh already holds one.
-      if gh release download "$micTarget" \
-           --repo lyric-tech/mic \
-           --pattern "mic_''${micOS}_''${micArch}.tar.gz" \
-           --output - 2>/dev/null | tar xz -C "$micTmp" mic; then
-        install -m 0755 "$micTmp/mic" "${binDir}/mic"
-        printf '%s\n' "$micTarget" > "$micMarker"
-        echo "mic: installed $micTarget"
-      else
-        echo "mic: download of $micTarget failed; leaving the existing install in place"
-      fi
-      rm -rf "$micTmp"
+        micTarget="${cfg.version}"
+        if [ "$micTarget" = "latest" ]; then
+          micTarget="$(gh release view --repo lyric-tech/mic --json tagName -q .tagName 2>/dev/null || true)"
+          if [ -z "$micTarget" ]; then
+            echo "mic: could not resolve the latest release; keeping the current install"
+            exit 0
+          fi
+        fi
+
+        micMarker="${binDir}/.mic-version"
+        if [ "$(cat "$micMarker" 2>/dev/null || true)" = "$micTarget" ] && [ -x "${binDir}/mic" ]; then
+          echo "mic $micTarget already installed"
+          exit 0
+        fi
+
+        mkdir -p "${binDir}"
+        micTmp="$(mktemp -d)"
+        # Streamed straight out of gh into tar: the asset lives on a private
+        # repo, so a plain curl would 404 without a token. gh already holds one.
+        if gh release download "$micTarget" \
+             --repo lyric-tech/mic \
+             --pattern "mic_''${micOS}_''${micArch}.tar.gz" \
+             --output - 2>/dev/null | tar xz -C "$micTmp" mic; then
+          install -m 0755 "$micTmp/mic" "${binDir}/mic"
+          printf '%s\n' "$micTarget" > "$micMarker"
+          echo "mic: installed $micTarget"
+        else
+          echo "mic: download of $micTarget failed; leaving the existing install in place"
+        fi
+        rm -rf "$micTmp"
+      ) || true
     '';
   };
 }

--- a/configs/npm/default.nix
+++ b/configs/npm/default.nix
@@ -33,15 +33,21 @@ in
 
       mkdir -p "$NPM_CONFIG_PREFIX"
 
+      # if/else rather than an early `exit`: home-manager concatenates every
+      # home.activation block into ONE bash script, so `exit` here would end the
+      # whole activation run — every step ordered after this one silently never
+      # runs. See configs/mic for the outage this actually caused.
       if ! command -v npm >/dev/null 2>&1; then
         echo "Skipping npm package install because npm is unavailable"
-        exit 0
+      else
+        # Keeps the branch non-empty when no packages are configured: `packages`
+        # defaults to [ ], and bash rejects an `else` with nothing in it.
+        :
+        ${lib.concatMapStringsSep "\n" (pkg: ''
+          echo "Installing npm package ${pkg}..."
+          npm install --global --location=global ${pkg}
+        '') cfg.packages}
       fi
-
-      ${lib.concatMapStringsSep "\n" (pkg: ''
-        echo "Installing npm package ${pkg}..."
-        npm install --global --location=global ${pkg}
-      '') cfg.packages}
     '';
   };
 }


### PR DESCRIPTION
## The bug

home-manager concatenates every `home.activation` block into a **single** bash script. So `exit 0` inside one block does not skip that module — it terminates the entire activation run.

`configs/mic` has six such early exits. The one that actually fires on a steady-state boot is the *success* path:

```bash
if [ "$(cat "$micMarker" ...)" = "$micTarget" ] && [ -x ".../mic" ]; then
  echo "mic $micTarget already installed"
  exit 0          # ← ends the whole activation script
fi
```

Because `installLyricMic` is ordered before `installPackages`, everything after it silently never ran:

`installPackages` · **`linkGeneration`** · `mergeGlobalMcpServers` · `npmPackages` · `onFilesChange` · `reloadSystemd` · `restoreAtuin` · `syncPrivateSkills` · `syncClaudeDocs` · `writeProjectLocalMcpServers`

The shape of the failure is what made it hard to spot: a **fresh volume converges correctly** (mic isn't installed yet, so it downloads and control falls out the bottom of the block). Every activation *after* that truncates. The machine converges exactly once, then stops — and exits `0`, so agentfest's entrypoint never printed its `home-manager activation FAILED` warning.

## Why it mattered on festie

`linkGeneration` is what re-points `~/.claude`, `~/.config/fish`, `~/.config/tmux`, `~/.config/git` and `~/.gnupg` at the current generation. The Nix store lives in the image layer; `$HOME` lives on the PVC. So after the next image bump, every one of those symlinks pointed into a store path that no longer existed.

Observed on the running container before this fix:

```
~/.config/tmux/tmux.conf    → dangling
~/.claude/settings.json     → dangling
~/.config/fish/config.fish  → dangling
~/.config/gopass/config     → dangling
~/.gnupg/gpg-agent.conf     → dangling
~/.config/git/config        → dangling
```

Concretely that meant: no `bypassPermissions` or `CLAUDE_CODE_EFFORT_LEVEL=max`, none of the session-tracker hooks, stock tmux (`C-b`, emacs keys), gpg-agent with no `pinentry-program` (so `pass`/`gopass` could not decrypt at all), month-old agent-smith skills — and no `commit.gpgsign`, so **commits made from festie were silently unsigned**.

## The fix

- **`configs/mic`** — body wrapped in a subshell `( … ) || true`, so its six early exits only exit the subshell. Same shape `configs/pass` already uses.
- **`configs/npm`**, **`configs/cargo`** — same latent defect, fires on any host without npm/cargo. Converted to if/else, with a `:` so the branch is still valid bash when the package list is empty (which is exactly how festie renders `npm`, and it does fail to build otherwise).

## Verification

- `nixpkgs-fmt --check .` → 0/30 reformatted
- `nix eval` + `nix build` of `homeConfigurations.festie.activationPackage` → builds clean
- Built activation package run against the live festie container: **20 steps ran, up from 9**, and all six symlinks above resolve again

Deploying this needs the usual chain afterwards: `nix flake update dotfiles` in `agentfest` → new image + chart → version bump in `homelab.setup`.