### PR TITLE
Fix festie's missing terminfo and project-local MCP directories

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -572,16 +572,22 @@ in
       PROJECT_DIR="${profile.path}"
       PROJECT_MCP_JSON="$PROJECT_DIR/.mcp.json"
 
-      if [ ! -d "$PROJECT_DIR" ]; then
-        echo "Skipping local MCP sync for missing directory: $PROJECT_DIR"
+      # Create the directory rather than skipping it. These paths are not
+      # incidental — they are where this module declares the profiles to live,
+      # so "missing" means the profile is dead, not that the host opted out. A
+      # fresh festie volume has neither ~/personal nor ~/work, and the old
+      # branch no-opped with a single line that read like a deliberate choice
+      # while every server in the profile silently never loaded.
+      #
+      # Idempotent, and a no-op on a host where the path is already a checkout.
+      mkdir -p "$PROJECT_DIR"
+
+      if [ -f "$PROJECT_MCP_JSON" ]; then
+        "$JQ_BIN" --argjson newServers '${builtins.toJSON profile.mcpServers}' \
+          '.mcpServers = $newServers' \
+          "$PROJECT_MCP_JSON" > "$PROJECT_MCP_JSON.tmp" && mv "$PROJECT_MCP_JSON.tmp" "$PROJECT_MCP_JSON"
       else
-        if [ -f "$PROJECT_MCP_JSON" ]; then
-          "$JQ_BIN" --argjson newServers '${builtins.toJSON profile.mcpServers}' \
-            '.mcpServers = $newServers' \
-            "$PROJECT_MCP_JSON" > "$PROJECT_MCP_JSON.tmp" && mv "$PROJECT_MCP_JSON.tmp" "$PROJECT_MCP_JSON"
-        else
-          echo '{"mcpServers":${builtins.toJSON profile.mcpServers}}' | "$JQ_BIN" '.' > "$PROJECT_MCP_JSON"
-        fi
+        echo '{"mcpServers":${builtins.toJSON profile.mcpServers}}' | "$JQ_BIN" '.' > "$PROJECT_MCP_JSON"
       fi
     '') mcpInventory.projectLocal}
   '';

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -28,6 +28,14 @@
       which
       less
       procps
+      # `clear`, `tput`, `reset`, `infocmp` — and, just as importantly, the
+      # terminfo database none of them work without. ninezeroes and trueswiftie
+      # both get this from the system underneath them; a standalone home-manager
+      # profile has no system, so festie had neither the binaries nor a terminfo
+      # entry for the TERM tmux hands its panes. `clear` was simply not on PATH,
+      # and anything else that queries terminfo (less, fzf, vim redraw) was
+      # working off defaults rather than the real terminal description.
+      ncurses
       zip
       unzip
       # TLS trust store; the image entrypoint points SSL_CERT_FILE at this


### PR DESCRIPTION
Two independent gaps found while debugging festie, one commit each.

## 1. `clear` doesn't exist (`feat: give festie ncurses`)

`clear` isn't broken on festie — it was never installed. Neither were `tput`, `reset` or `infocmp`, nor the terminfo database that all of them need:

```
$ command -v clear tput reset infocmp
(nothing)
$ ls ~/.local/state/nix/profiles/home-manager/home-path/share/terminfo
(no such directory)
```

`ninezeroes` and `trueswiftie` both inherit ncurses from the system underneath them. `festie` is a standalone home-manager profile with **no system**, so nothing supplied it and nothing in the host package list asked for it.

The visible symptom is `clear` returning command-not-found in any shell. The quieter one is that anything resolving the current `TERM` (tmux hands its panes `tmux-256color`) finds no terminfo entry and falls back to a built-in default rather than the real terminal description — which affects redraw behaviour in `less`, `fzf` and vim.

## 2. Project-local MCP profiles silently never landed (`fix: create the project-local MCP directories`)

`writeProjectLocalMcpServers` skipped any declared path that didn't exist:

```bash
if [ ! -d "$PROJECT_DIR" ]; then
  echo "Skipping local MCP sync for missing directory: $PROJECT_DIR"
```

That line reads like a deliberate opt-out, but these paths aren't incidental — they're where this module *declares the profiles to live*. A missing directory means every server in the profile is declared and dead.

A fresh festie volume has neither `~/personal` nor `~/work`, so both profiles silently never landed: `zomato`/`strava`/`hevy`, and the four Lyric servers including `notprod-lyric-deploy` (the one `configs/mic` exists specifically to provide a binary for).

They did eventually appear on the running container, but only because agent-smith declares skill `roots` underneath them and `claude-skills` `mkdir -p`s its destinations — an accident of DAG ordering (`syncPrivateSkills` runs before `writeProjectLocalMcpServers`) rather than anything to rely on.

`mkdir -p` is idempotent and a no-op wherever the path is already a checkout, which is every other host.

## Verification

- `nixpkgs-fmt --check .` → 0/30 reformatted
- `nix build .#homeConfigurations.festie.activationPackage` → builds clean
- Confirmed on the live container that both `.mcp.json` files now carry their full server sets

## Note on ordering

This branches off `main` and is independent of #88, but in practice #88 needs to land first — until `linkGeneration` runs again, neither of these changes can reach a running festie.