### PR TITLE
Make festie's remaining runtime state declarative

### DIFF
--- a/configs/codeman/default.nix
+++ b/configs/codeman/default.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+# Codeman's case registry, declared rather than clicked.
+#
+# A "case" is just a named working directory Codeman remembers. Cases created
+# through the UI live under ~/codeman-cases/<name>, but Codeman can also point a
+# case at a folder anywhere on disk, and it records those in
+# ~/.codeman/linked-cases.json.
+#
+# That file is pure runtime state: it is written by `POST /api/cases/link` and
+# rewritten on every link/unlink from the UI. On festie it sits on the PVC, so a
+# case linked by hand survives restarts — and is lost the moment the machine is
+# rebuilt somewhere else, with no trace in any repo explaining what used to be
+# there. Declaring the links here is what makes the working directories a
+# property of the configuration instead of a property of one volume.
+
+let
+  cfg = config.programs.codeman;
+  dataDir = "${config.home.homeDirectory}/.codeman";
+  linkedCasesFile = "${dataDir}/linked-cases.json";
+in
+{
+  options.programs.codeman = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Manage Codeman's linked-case registry. Only meaningful on a host that
+        actually runs Codeman — festie, the agentfest container.
+      '';
+    };
+
+    linkedCases = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = { work = "/home/rounak/work"; };
+      description = ''
+        Case name -> absolute path, merged into ~/.codeman/linked-cases.json.
+        Each path is created if missing, mirroring what the link API requires.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.linkedCases != { }) {
+    home.activation.codemanLinkedCases = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      (
+        JQ_BIN="${pkgs.jq}/bin/jq"
+
+        mkdir -p "${dataDir}"
+
+        # Each declared path has to exist before Codeman will resolve a case to
+        # it; the link API rejects a missing folder outright. Creating them here
+        # keeps this module self-contained rather than depending on whichever
+        # other activation step happens to run first.
+        ${lib.concatMapStringsSep "\n        " (name: ''
+        mkdir -p "${cfg.linkedCases.${name}}"
+        '') (builtins.attrNames cfg.linkedCases)}
+
+        # Merge, never clobber. Codeman owns this file at runtime, so anything
+        # linked from the UI has to survive an activation — only the declared
+        # names are asserted. Same shape as configs/claude's
+        # mergeGlobalMcpServers, including the tolerance for a corrupt file:
+        # a registry we cannot parse is replaced rather than allowed to wedge
+        # every case on the machine.
+        if [ -f "${linkedCasesFile}" ] && "$JQ_BIN" -e . "${linkedCasesFile}" >/dev/null 2>&1; then
+          "$JQ_BIN" --argjson declared '${builtins.toJSON cfg.linkedCases}' \
+            '. * $declared' "${linkedCasesFile}" > "${linkedCasesFile}.tmp" \
+            && mv "${linkedCasesFile}.tmp" "${linkedCasesFile}"
+        else
+          printf '%s\n' '${builtins.toJSON cfg.linkedCases}' \
+            | "$JQ_BIN" '.' > "${linkedCasesFile}"
+        fi
+      ) || true
+    '';
+  };
+}

--- a/configs/default.nix
+++ b/configs/default.nix
@@ -13,6 +13,7 @@
     ./nextcloud
     ./emacs
     ./claude
+    ./codeman
     ./go
     ./cargo
     ./mic

--- a/configs/git/default.nix
+++ b/configs/git/default.nix
@@ -2,57 +2,100 @@
 let
   user = import ../../lib/user.nix;
   passwordStoreDir = "${config.home.homeDirectory}/.password-store";
+  cfg = config.programs.githubOverSsh;
 in
 {
-  programs.git = {
-    enable = true;
-    signing = {
-      format = "openpgp";
-      key = user.gpgKey;
-      signByDefault = true;
-    };
-    # the goal here is to have the correct ordering, the `[user]` block should come first, and then the `[include]` block
-    # was able to fix the ordering using https://www.reddit.com/r/NixOS/comments/jg4i92/comment/j08vf4n
-    includes = [
-      {
-        condition = "gitdir:~/work/";
-        contents = {
-          user = {
-            name = "Rounak Datta";
-            email = "rounak@lyric.tech";
-            signingKey = "A04E86FD28F5A421";
-          };
-        };
-      }
-      { path = "~/.gitconfig.https"; }
-    ];
-    settings = {
-      user = {
-        email = user.email;
-        name = "Rounak Datta";
-      };
-      diff.external = "difft";
+  options.programs.githubOverSsh = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Rewrite GitHub HTTPS remotes to SSH, and stop writing the PAT-bearing
+        ~/.gitconfig.https.
+
+        For hosts where the PAT path is not deterministic. It depends on
+        gopass, which depends on the GPG key being unlocked *at activation
+        time* — and on a freshly booted festie nobody has unlocked it yet, so
+        the file is silently never written and every push fails with
+        "could not read Username for 'https://github.com'". Whether git works
+        then depends on whether a human happened to decrypt something first.
+
+        The mounted SSH key has no passphrase and is already what configs/ssh
+        points github.com at, so routing git over it removes the ordering
+        dependency entirely. Commit *signing* still needs the key unlocked;
+        that is a separate concern from transport.
+      '';
     };
   };
 
-  # TODO: Beware! As long as this activation is there, changes made above will not take effect
-  # you gotta comment the following section out to make changes above take effect
-  home.activation = {
-    createTokenIncludedGitHubHttpsConfig = lib.hm.dag.entryAfter [ "passwordStore" ] ''
-      export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
-      export PATH="/usr/bin:$PATH"
-
-      GITCONFIG_HTTPS_FILE=${config.home.homeDirectory}/.gitconfig.https
-
-      # the store is set up out-of-band, so this no-ops until `.gpg-id` exists;
-      # gating on it avoids gopass' "not initialized" error and a pinentry hang
-      if [ -f "${passwordStoreDir}/.gpg-id" ] && GH_PAT=$(gopass show github.com/pat 2>/dev/null) && [ -n "$GH_PAT" ]; then
+  # Everything below sits under an explicit `config`, which the options block
+  # above makes mandatory: a module that declares top-level `options` may not
+  # also carry bare configuration attributes.
+  config = {
+    programs.git = {
+      enable = true;
+      signing = {
+        format = "openpgp";
+        key = user.gpgKey;
+        signByDefault = true;
+      };
+      # the goal here is to have the correct ordering, the `[user]` block should come first, and then the `[include]` block
+      # was able to fix the ordering using https://www.reddit.com/r/NixOS/comments/jg4i92/comment/j08vf4n
+      includes = [
         {
-          echo "[url \"https://rounakdatta:$GH_PAT@github.com/\"]"
-          echo "  insteadOf = https://github.com/"
-        } > "$GITCONFIG_HTTPS_FILE"
-      fi
-    '';
+          condition = "gitdir:~/work/";
+          contents = {
+            user = {
+              name = "Rounak Datta";
+              email = "rounak@lyric.tech";
+              signingKey = "A04E86FD28F5A421";
+            };
+          };
+        }
+        { path = "~/.gitconfig.https"; }
+      ];
+      settings = {
+        user = {
+          email = user.email;
+          name = "Rounak Datta";
+        };
+        diff.external = "difft";
+      } // lib.optionalAttrs cfg.enable {
+        # Deliberately the only insteadOf rule on such a host: the PAT include
+        # declares the same rewrite, and two live rules for one prefix make
+        # which credential git picks a coin flip.
+        url."git@github.com:".insteadOf = "https://github.com/";
+      };
+    };
+
+    # TODO: Beware! As long as this activation is there, changes made above will not take effect
+    # you gotta comment the following section out to make changes above take effect
+    home.activation = {
+      createTokenIncludedGitHubHttpsConfig = lib.hm.dag.entryAfter [ "passwordStore" ] (
+        if cfg.enable then ''
+          # This host routes GitHub over SSH, so the PAT include must not merely
+          # go unwritten — it must be actively removed. A copy left behind by an
+          # earlier generation (or by an activation that ran while the key
+          # happened to be unlocked) is still on disk and still included, and it
+          # would race the SSH rewrite for the same prefix.
+          rm -f "${config.home.homeDirectory}/.gitconfig.https"
+        '' else ''
+          export PATH="${config.home.path}/bin:/run/current-system/sw/bin:/etc/profiles/per-user/${config.home.username}/bin:$PATH"
+          export PATH="/usr/bin:$PATH"
+
+          GITCONFIG_HTTPS_FILE=${config.home.homeDirectory}/.gitconfig.https
+
+          # the store is set up out-of-band, so this no-ops until `.gpg-id` exists;
+          # gating on it avoids gopass' "not initialized" error and a pinentry hang
+          if [ -f "${passwordStoreDir}/.gpg-id" ] && GH_PAT=$(gopass show github.com/pat 2>/dev/null) && [ -n "$GH_PAT" ]; then
+            {
+              echo "[url \"https://rounakdatta:$GH_PAT@github.com/\"]"
+              echo "  insteadOf = https://github.com/"
+            } > "$GITCONFIG_HTTPS_FILE"
+          fi
+        ''
+      );
+    };
   };
 }
 

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -174,6 +174,19 @@
       privateRepo.url = "git@github.com:rounakdatta/agent-smith.git";
     };
 
+    # Codeman is this machine's UI, and the cases it offers are the working
+    # directories you actually land in. Declared here so a rebuilt festie comes
+    # up pointing at ~/personal and ~/work rather than only at
+    # ~/codeman-cases/<name> — the registry behind this is runtime state on the
+    # PVC, so a link made by hand does not survive being deployed elsewhere.
+    codeman = {
+      enable = true;
+      linkedCases = {
+        personal = "${config.home.homeDirectory}/personal";
+        work = "${config.home.homeDirectory}/work";
+      };
+    };
+
     # configs/claude declares the notprod-lyric-deploy MCP server as
     # `command = "mic"` for ~/work, and that block is not platform-gated — so
     # it lands here too. Without this the server is declared and dead, which is

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -187,6 +187,13 @@
       };
     };
 
+    # The PAT-over-HTTPS path is not deterministic on a container that boots
+    # with a locked GPG key — see the option's description in configs/git. The
+    # mounted SSH key needs no passphrase, so git uses that instead.
+    githubOverSsh = {
+      enable = true;
+    };
+
     # configs/claude declares the notprod-lyric-deploy MCP server as
     # `command = "mic"` for ~/work, and that block is not platform-gated — so
     # it lands here too. Without this the server is declared and dead, which is


### PR DESCRIPTION
Two pieces of festie's behaviour existed only as live state on the PVC. Neither would survive a move to another deployment, and neither left any trace in a repo explaining what used to be there. One commit each.

## 1. Codeman's linked cases (`feat: declare Codeman's linked cases`)

A Codeman "case" is a named working directory. Cases created in the UI live under `~/codeman-cases/<name>`, but a case can point anywhere on disk — Codeman records those in `~/.codeman/linked-cases.json`.

That file is pure runtime state, written by `POST /api/cases/link` and rewritten on every link/unlink. Nothing in any repo produces it.

This matters more than "which folder am I in": `configs/claude` declares its project-local MCP profiles against `~/personal` and `~/work` specifically, and agent-smith scopes skills to the same roots. A rebuilt festie that only offers `~/codeman-cases/<name>` puts you in a directory where none of that applies, with no obvious reason why.

New `configs/codeman` module; festie declares both cases.

The merge is deliberate rather than a rewrite — Codeman owns this file at runtime, so anything linked from the UI survives an activation and only the declared names are asserted. Same shape as `configs/claude`'s `mergeGlobalMcpServers`, including replacing a file that no longer parses rather than letting it wedge every case on the machine. `home.file` would be wrong here: a read-only store symlink would break Codeman's own writes.

## 2. Git transport (`fix: route festie's git over ssh`)

`createTokenIncludedGitHubHttpsConfig` writes `~/.gitconfig.https` only if `gopass show github.com/pat` succeeds — which needs the GPG key unlocked **at activation time**. On a freshly booted festie nobody has unlocked it, so the file is silently never written and every push fails with:

```
fatal: could not read Username for 'https://github.com'
```

So whether git works depends on whether a human happened to decrypt something earlier in the pod's life. That is exactly what happened today: the first push from this container failed, and the identical push succeeded after an unrelated unlock.

The mounted SSH key has no passphrase and is already what `configs/ssh` points `github.com` at, so routing transport over it removes the ordering dependency entirely. Commit *signing* still needs the key unlocked — separate concern, deliberately unchanged.

The option also **removes** a stale `~/.gitconfig.https` rather than merely not writing one: a copy left by an earlier generation is still on disk and still included, and two live `insteadOf` rules for one prefix make which credential git picks a coin flip.

Off by default (`programs.githubOverSsh.enable`), so trueswiftie and ninezeroes keep the PAT path.

Note `configs/git` gains a top-level `options` block, which forces its existing attributes under an explicit `config` — that is the reason for the indentation churn in that file.

## Verification

- `nixpkgs-fmt --check .` → 0/31 reformatted
- All three host configs evaluate (`ninezeroes`, `trueswiftie`, `festie`) — the first build failed until `configs/codeman` was `git add`ed, since flakes only see tracked files
- Applied to the live container: activation ran 21 steps, `linked-cases.json` holds both cases, `~/.gitconfig.https` is gone, and `git ls-remote` resolves over `git@github.com:` with no PAT and no gpg involved — this PR was pushed over exactly that path