### PR TITLE
Ship festie-doctor and festie-unlock

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -14,6 +14,7 @@
     ./emacs
     ./claude
     ./codeman
+    ./festie-doctor
     ./go
     ./cargo
     ./mic

--- a/configs/festie-doctor/default.nix
+++ b/configs/festie-doctor/default.nix
@@ -1,0 +1,274 @@
+{ config, lib, pkgs, ... }:
+
+# festie-doctor — assert the container actually converged.
+#
+# festie is the one host where "did home-manager finish?" is a question worth
+# asking automatically. Its Nix store lives in an image layer while $HOME lives
+# on a PVC, so the two can disagree: activation that stops early leaves the home
+# directory pinned to a generation the running image no longer carries, and
+# every symlink in it dangles. That is not hypothetical — it is exactly what
+# configs/mic's `exit 0` caused, silently, on every boot for days, while the
+# entrypoint reported success because exiting 0 is indistinguishable from
+# finishing.
+#
+# Deliberately hash-free, so it needs no pinned version and stays correct across
+# every image bump on its own. A version-stamped doctor is a doctor nobody
+# updates. Two questions are asked separately, because they fail for different
+# reasons and a single check would report the wrong cause for half of them:
+#
+#   1. is the active generation the one $AGENTFEST_HOME_ACTIVATION baked in?
+#      (no  =>  activation did not run this boot, or something was activated by
+#      hand)
+#   2. does every managed file resolve to the ACTIVE generation's copy?
+#      (no  =>  activation started but never reached linkGeneration)
+#
+# The bug this exists for failed (2) while passing (1): the profile generation
+# is created at writeBoundary, long before the step that relinks the files, so a
+# run that dies in between leaves a current-looking generation and a home
+# directory still pointing at the previous one.
+#
+# The shell body below is deliberately ASCII-only: writeShellApplication runs
+# shellcheck at build time, and shellcheck's output encoder dies on a non-ASCII
+# character in any line it wants to quote back at you.
+
+let
+  cfg = config.programs.festie-doctor;
+
+  # The load-bearing files, each with the capability it gates. Kept explicit
+  # rather than derived from config.home.file: that would also enumerate the
+  # whole skills tree, and the point here is a short, readable verdict on the
+  # things whose absence breaks the machine in a way that is hard to diagnose
+  # from the symptom.
+  managedFiles = {
+    ".claude/settings.json" = "claude permissions, hooks and effort level";
+    ".config/fish/config.fish" = "shell configuration";
+    ".config/git/config" = "git identity, signing and url rewrites";
+    ".config/gopass/config" = "gopass mount, and so every pass-backed MCP server";
+    ".config/tmux/tmux.conf" = "tmux keys and status line";
+    ".gnupg/gpg-agent.conf" = "pinentry, and so whether pass can decrypt at all";
+  };
+
+  # Priming the agent is a separate command from checking it, because it needs
+  # something the checker never has: a terminal. pinentry-curses draws on the
+  # tty, so this cannot run from an activation step, a hook, or an agent's tool
+  # call - only from a shell someone is actually looking at.
+  unlock = pkgs.writeShellApplication {
+    name = "festie-unlock";
+    runtimeInputs = with pkgs; [ coreutils findutils gnupg ];
+    text = ''
+      if [ ! -t 1 ]; then
+        echo "festie-unlock needs a terminal; pinentry-curses draws on the tty." >&2
+        echo "Run it from a shell pane, not from a script or an agent tool call." >&2
+        exit 1
+      fi
+      GPG_TTY="$(tty)"
+      export GPG_TTY
+
+      # Sign and decrypt are cached SEPARATELY, keyed by keygrip. This is the
+      # trap worth automating away: unlocking for `git commit` primes the [SC]
+      # key only, and leaves pass, gopass and every pass-backed MCP server just
+      # as locked as before - with no error until something quietly fails to
+      # start. Prime both, once, deliberately.
+
+      echo "priming the signing key..."
+      printf 'festie-unlock' | gpg --clearsign >/dev/null
+
+      echo "priming the decryption key..."
+      secret="$(find "$HOME/.password-store" -name '*.gpg' -print -quit 2>/dev/null || true)"
+      if [ -n "$secret" ]; then
+        gpg --decrypt "$secret" >/dev/null
+      else
+        echo "no password store entries found; decryption key left unprimed" >&2
+      fi
+
+      # Report the capability, not gpg-agent's key-cache flag: decryption can be
+      # satisfied from the passphrase cache without the key cache ever showing
+      # it, so `keyinfo` reports "locked" on a key that works. See the doctor.
+      echo
+      if printf 'x' | gpg --batch --no-tty --clearsign >/dev/null 2>&1; then
+        printf '  \033[32mready\033[0m   signing (git commit)\n'
+      else
+        printf '  \033[31mlocked\033[0m  signing (git commit)\n'
+      fi
+      if [ -n "$secret" ] && gpg --batch --no-tty --decrypt "$secret" >/dev/null 2>&1; then
+        printf '  \033[32mready\033[0m   decryption (pass, gopass, MCP servers)\n'
+      else
+        printf '  \033[31mlocked\033[0m  decryption (pass, gopass, MCP servers)\n'
+      fi
+      echo
+      echo "Cached until this pod restarts. Re-run after any deploy."
+    '';
+  };
+
+  doctor = pkgs.writeShellApplication {
+    name = "festie-doctor";
+    # Declared rather than left to the inherited PATH: this runs on a machine
+    # whose whole failure mode is an environment that did not come up the way it
+    # should have, so it must not depend on one.
+    runtimeInputs = with pkgs; [ coreutils findutils gnugrep git gnupg ncurses openssh ];
+    text = ''
+      fails=0
+      pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+      fail() { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; fails=$((fails + 1)); }
+      note() { printf '        %s\n' "$1"; }
+
+      baked="''${AGENTFEST_HOME_ACTIVATION:-}"
+      current="$(readlink -f "$HOME/.local/state/nix/profiles/home-manager" 2>/dev/null || true)"
+
+      # A file that merely exists proves nothing: after a truncated activation
+      # the old symlink still resolves, right up until the store path behind it
+      # vanishes with the next image. Comparing the target to the ACTIVE
+      # generation's own copy is what catches a home directory that has stopped
+      # tracking it.
+      #
+      # Compared against the active generation rather than the image's, and the
+      # two are asserted equal separately below. They diverge for two very
+      # different reasons - activation never finished, or someone activated a
+      # locally built generation by hand - and collapsing them into one check
+      # reports the wrong cause for half the failures.
+      check_managed() {
+        local rel="$1" why="$2" want have
+        want="$(readlink -f "$current/home-files/$rel" 2>/dev/null || true)"
+        have="$(readlink -f "$HOME/$rel" 2>/dev/null || true)"
+        if [ -z "$have" ]; then
+          fail "$HOME/$rel is missing or dangling"
+          note "gates: $why"
+        elif [ -z "$want" ]; then
+          note "$HOME/$rel not shipped by this image; skipped"
+        elif [ "$want" = "$have" ]; then
+          pass "$HOME/$rel"
+        else
+          fail "$HOME/$rel points at a stale generation"
+          note "gates: $why"
+        fi
+      }
+
+      printf '\n=== activation ===\n'
+      if [ -z "$current" ]; then
+        fail "no active home-manager generation; activation has never run here"
+      elif [ -z "$baked" ]; then
+        note "AGENTFEST_HOME_ACTIVATION unset; not inside the agentfest image"
+        pass "active generation $current"
+      elif [ "$current" = "$baked" ]; then
+        pass "active generation is the one this image baked"
+      else
+        fail "active generation is not the image's"
+        note "image:  $baked"
+        note "active: $current"
+        note "either activation did not run this boot, or a generation was activated by hand"
+      fi
+
+      printf '\n=== home-manager files track the active generation ===\n'
+      if [ -n "$current" ] && [ -d "$current/home-files" ]; then
+        ${lib.concatStringsSep "\n        " (lib.mapAttrsToList (f: why: ''check_managed "${f}" "${why}"'') managedFiles)}
+      else
+        fail "skipped; no active generation to compare against"
+      fi
+
+      printf '\n=== capabilities ===\n'
+      if grep -q '"defaultMode":"bypassPermissions"' "$HOME/.claude/settings.json" 2>/dev/null; then
+        pass "claude runs in bypassPermissions"
+      else
+        fail "claude settings.json is missing or not the nix-managed one"
+      fi
+      if grep -q "pinentry" "$HOME/.gnupg/gpg-agent.conf" 2>/dev/null; then
+        pass "gpg-agent has a pinentry-program"
+      else
+        fail "no pinentry-program; pass, gopass and pass-backed MCP servers cannot decrypt"
+      fi
+      if command -v clear >/dev/null 2>&1 && infocmp -1 "''${TERM:-xterm-256color}" >/dev/null 2>&1; then
+        pass "clear and terminfo for TERM=''${TERM:-unset}"
+      else
+        fail "clear or terminfo missing for TERM=''${TERM:-unset}"
+      fi
+
+      printf '\n=== project roots ===\n'
+      for d in personal work; do
+        if [ -f "$HOME/$d/.mcp.json" ]; then
+          pass "$HOME/$d/.mcp.json"
+        else
+          fail "$HOME/$d/.mcp.json missing; that profile's MCP servers are declared and dead"
+        fi
+      done
+      if grep -q '"personal"' "$HOME/.codeman/linked-cases.json" 2>/dev/null \
+        && grep -q '"work"' "$HOME/.codeman/linked-cases.json" 2>/dev/null; then
+        pass "codeman cases personal and work linked"
+      else
+        fail "linked-cases.json missing personal and/or work"
+      fi
+
+      # Loud on purpose. The passphrase cache lives in gpg-agent's memory, so it
+      # dies with the pod - every deploy locks the machine again. Left silent,
+      # the way you find out is a pass-backed MCP server that simply never
+      # appears, which looks like a config problem and is not one.
+      #
+      # Sign and decrypt are cached separately by keygrip, so both are reported:
+      # unlocking for a commit does nothing for pass.
+      printf '\n=== gpg agent (cache dies with the pod) ===\n'
+      # Probe the CAPABILITY, never the agent's bookkeeping. `keyinfo --list`
+      # reports gpg-agent's private-KEY cache, and decryption can satisfy itself
+      # from the separate PASSPHRASE cache without ever populating it - observed
+      # here reporting the [E] key as uncached while `pass show` worked fine. A
+      # checker that cries wolf is worse than no checker, so ask the only
+      # question that matters: does the operation complete with no tty to prompt
+      # on? That is precisely the situation an MCP server is spawned into.
+      before_gpg="$fails"
+      if printf 'x' | gpg --batch --no-tty --clearsign >/dev/null 2>&1; then
+        pass "signing works with no tty"
+      else
+        fail "signing would prompt; git commit will block"
+      fi
+      probe="$(find "$HOME/.password-store" -name '*.gpg' -print -quit 2>/dev/null || true)"
+      if [ -z "$probe" ]; then
+        note "password store has no entries; decryption not probed"
+      elif gpg --batch --no-tty --decrypt "$probe" >/dev/null 2>&1; then
+        pass "decryption works with no tty (pass, gopass, MCP servers)"
+      else
+        fail "decryption would prompt; pass-backed MCP servers will not start"
+      fi
+      if [ "$fails" -gt "$before_gpg" ]; then
+        note "run 'festie-unlock' in a terminal to prime both keys"
+      fi
+
+      # Transport must work with the GPG key still locked, which is the whole
+      # reason festie routes github over ssh. It is checked below precisely
+      # because it must pass even when the section above fails.
+      printf '\n=== git transport with the key locked ===\n'
+      if [ -e "$HOME/.gitconfig.https" ]; then
+        fail "$HOME/.gitconfig.https present; it races the ssh insteadOf rule"
+      else
+        pass "no stale PAT include"
+      fi
+      if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new" \
+         timeout 45 git ls-remote https://github.com/rounakdatta/dotfiles HEAD >/dev/null 2>&1; then
+        pass "git ls-remote succeeds without unlocking anything"
+      else
+        fail "git ls-remote failed; transport depends on something unavailable at boot"
+      fi
+
+      printf '\n'
+      if [ "$fails" -eq 0 ]; then
+        printf '\033[32mconverged - all checks passed\033[0m\n\n'
+      else
+        printf '\033[31m%d check(s) failed\033[0m\n\n' "$fails"
+      fi
+      [ "$fails" -eq 0 ]
+    '';
+  };
+in
+{
+  options.programs.festie-doctor = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Install festie-doctor, a convergence check for the agentfest container.
+        Only meaningful where $AGENTFEST_HOME_ACTIVATION is set.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ doctor unlock ];
+  };
+}

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -187,6 +187,14 @@
       };
     };
 
+    # `festie-doctor` — one command that says whether this container actually
+    # converged. Worth shipping rather than remembering: the failure it detects
+    # is silent by construction, and the entrypoint deliberately continues past
+    # a broken activation so a healthy-looking pod proves nothing.
+    festie-doctor = {
+      enable = true;
+    };
+
     # The PAT-over-HTTPS path is not deterministic on a container that boots
     # with a locked GPG key — see the option's description in configs/git. The
     # mounted SSH key needs no passphrase, so git uses that instead.


### PR DESCRIPTION
Two small commands for the container, both born out of failures from this week rather than imagined ones.

## `festie-doctor` — did this pod actually converge?

The failure it exists for is silent by construction. festie's Nix store lives in an image layer while `$HOME` lives on a PVC, so the two can disagree: an activation that stops early leaves the home directory pinned to a generation the running image no longer carries, and every symlink in it dangles. The entrypoint deliberately continues past a broken activation so the terminal stays reachable — which means **a healthy-looking pod proves nothing**.

It asks two questions separately, because they fail for different reasons and one combined check would report the wrong cause for half of them:

1. Is the active generation the one `AGENTFEST_HOME_ACTIVATION` baked in? *No ⇒ activation didn't run this boot, or one was activated by hand.*
2. Does every managed file resolve to the **active** generation's copy? *No ⇒ activation started but never reached `linkGeneration`.*

`configs/mic`'s `exit 0` **failed (2) while passing (1)**. The profile generation is created at `writeBoundary`, long before the step that relinks the files, so a run dying in between leaves a current-looking generation beside a home directory still pointing at the previous one. A doctor that only checked the generation would have called that machine healthy.

Deliberately hash-free, so it stays correct across every image bump without being edited. A version-stamped doctor is a doctor nobody updates.

## `festie-unlock` — prime both keys, once

The passphrase cache lives in gpg-agent's memory, so it dies with the pod: every deploy locks the machine again. `~/.gnupg` persists on the PVC, but the agent is a process.

Worse, **sign and decrypt are cached separately, by keygrip**. Unlocking for a `git commit` primes the `[SC]` key only and leaves `pass`, `gopass` and every pass-backed MCP server just as locked — with no error until a server quietly fails to start. Captured mid-session:

```
8CA0C31E…  [SC]  cached=1     <- after a commit unlock
C4D02904…  [E]   cached=-     <- pass still locked
```

`festie-unlock` primes both deliberately. It needs a terminal, which neither an activation step nor an agent tool call has, so it's a separate command from the checker rather than something that could run at boot.

## Both report capability, not bookkeeping

Worth calling out, because the first implementation got this wrong and was caught in testing.

`keyinfo --list` exposes gpg-agent's private-**key** cache, which decryption can satisfy from the separate **passphrase** cache without ever populating. It reported `[E]` as uncached while `pass show` worked perfectly — a false FAIL. Both tools now probe the real question instead:

```
gpg --batch --no-tty --clearsign   # can we sign with nothing to prompt on?
gpg --batch --no-tty --decrypt     # can pass/MCP read a secret?
```

That is exactly the situation an MCP server is spawned into. A checker that cries wolf is worse than no checker.

## Notes

- Transport is checked too, and deliberately sits *below* the gpg section: it must pass even when both keys are locked, which is the entire reason festie routes GitHub over SSH.
- The shell bodies are ASCII-only. `writeShellApplication` runs shellcheck at build time, and its output encoder **crashes** on a non-ASCII character in any line it wants to quote — em dashes broke the build outright.

## Verification

`nixpkgs-fmt --check .` clean; builds clean (shellcheck runs in the build). Run against this live container in both states — 2 FAILs with the keys locked, naming the remedy; 17/17 PASS and exit 0 once primed.