### PR TITLE
Make byoc a case of its own, with the MCP servers to match

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -485,61 +485,78 @@ let
       }
       {
         path = "${homeDir}/work";
-        mcpServers = {
-          notprod-grafana-lyric = {
-            command = "bash";
-            args = [
-              "-c"
-              ''
-                GRAFANA_URL="https://notprod-grafana.lyric.tech"
-                GRAFANA_SERVICE_ACCOUNT_TOKEN="$(pass show api-keys/notprod-grafana-lyric)"
-
-                exec uvx mcp-grafana \
-                  -t stdio \
-                  -debug
-              ''
-            ];
-          };
-          prod-grafana-lyric = {
-            command = "bash";
-            args = [
-              "-c"
-              ''
-                GRAFANA_URL="https://prod-grafana.lyric.tech/"
-                GRAFANA_SERVICE_ACCOUNT_TOKEN="$(pass show api-keys/prod-grafana-lyric)"
-
-                exec uvx mcp-grafana \
-                  -t stdio \
-                  -debug
-              ''
-            ];
-          };
-          notprod-lyric-deploy = {
-            command = "mic";
-            args = [
-              "mcp"
-            ];
-          };
-          # Lyric Prototype platform (https://prototype.lyric.tech/mcp): a remote
-          # HTTP MCP server bridged to stdio via mcp-remote (like
-          # android-remote-control above). The scoped bearer key is read from
-          # pass at launch and passed as an Authorization header, so it never
-          # lands in .mcp.json — same approach as the grafana entries. Mint the
-          # key under Prototype > Developer Tools, then create the pass entry:
-          #   pass insert api-keys/lyric-prototype
-          lyric-prototype = {
-            command = "bash";
-            args = [
-              "-c"
-              ''
-                exec npx -y mcp-remote@latest https://prototype.lyric.tech/mcp \
-                  --header "Authorization: Bearer $(pass show api-keys/lyric-prototype)"
-              ''
-            ];
-          };
-        };
+        mcpServers = lyricWorkMcpServers;
+      }
+      {
+        # byoc is a Codeman case in its own right, so sessions start with it as
+        # the working directory — and project MCP resolves from <cwd>/.mcp.json
+        # with no walk upwards. Skills do climb (Claude Code reads each ancestor
+        # that has a CLAUDE.md, and both levels here do), which makes the
+        # asymmetry easy to miss: a session started in byoc would see all of its
+        # skills and none of Lyric's servers, `notprod-lyric-deploy` — the one
+        # those skills lean on — included.
+        #
+        # Same servers as the parent rather than a subset: byoc work is Lyric
+        # work, and a second list would drift the moment either is edited.
+        path = "${homeDir}/work/byoc";
+        mcpServers = lyricWorkMcpServers;
       }
     ];
+  };
+
+  # Shared by ~/work and ~/work/byoc, see the note above.
+  lyricWorkMcpServers = {
+    notprod-grafana-lyric = {
+      command = "bash";
+      args = [
+        "-c"
+        ''
+          GRAFANA_URL="https://notprod-grafana.lyric.tech"
+          GRAFANA_SERVICE_ACCOUNT_TOKEN="$(pass show api-keys/notprod-grafana-lyric)"
+
+          exec uvx mcp-grafana \
+            -t stdio \
+            -debug
+        ''
+      ];
+    };
+    prod-grafana-lyric = {
+      command = "bash";
+      args = [
+        "-c"
+        ''
+          GRAFANA_URL="https://prod-grafana.lyric.tech/"
+          GRAFANA_SERVICE_ACCOUNT_TOKEN="$(pass show api-keys/prod-grafana-lyric)"
+
+          exec uvx mcp-grafana \
+            -t stdio \
+            -debug
+        ''
+      ];
+    };
+    notprod-lyric-deploy = {
+      command = "mic";
+      args = [
+        "mcp"
+      ];
+    };
+    # Lyric Prototype platform (https://prototype.lyric.tech/mcp): a remote
+    # HTTP MCP server bridged to stdio via mcp-remote (like
+    # android-remote-control above). The scoped bearer key is read from
+    # pass at launch and passed as an Authorization header, so it never
+    # lands in .mcp.json — same approach as the grafana entries. Mint the
+    # key under Prototype > Developer Tools, then create the pass entry:
+    #   pass insert api-keys/lyric-prototype
+    lyric-prototype = {
+      command = "bash";
+      args = [
+        "-c"
+        ''
+          exec npx -y mcp-remote@latest https://prototype.lyric.tech/mcp \
+            --header "Authorization: Bearer $(pass show api-keys/lyric-prototype)"
+        ''
+      ];
+    };
   };
 in
 {

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -184,6 +184,12 @@
       linkedCases = {
         personal = "${config.home.homeDirectory}/personal";
         work = "${config.home.homeDirectory}/work";
+        # A case of its own rather than a directory to cd into after launching:
+        # Codeman starts a session in the case directory, and both the skill set
+        # and the MCP servers are resolved once at startup, so changing
+        # directory afterwards picks up neither. configs/claude gives this path
+        # its own .mcp.json for the same reason.
+        byoc = "${config.home.homeDirectory}/work/byoc";
       };
     };
 


### PR DESCRIPTION
Codeman starts a session **in** the case directory, and both the skill set and the MCP servers are resolved once at startup — so "launch in `work` and `cd` into `byoc`" picks up neither. byoc has to be a case.

## Linking it alone would only half-work

This is the part worth writing down, because the asymmetry is easy to misread:

- **Skills climb.** Claude Code reads `<cwd>/.claude/skills`, then each ancestor carrying a `CLAUDE.md`. Both `~/work/byoc` and `~/work` have one, so a session there already sees byoc's 4 skills *and* work's 3.
- **Project MCP does not climb.** It resolves `<cwd>/.mcp.json` and stops.

So a session launched in byoc would see every byoc skill and **none** of Lyric's servers — `notprod-lyric-deploy` included, which is exactly the one those skills lean on.

Hence `configs/claude` now gives `~/work/byoc` its own `.mcp.json`. Same servers as the parent rather than a subset: byoc work is Lyric work, and two lists would drift the moment either is edited — so they share a `lyricWorkMcpServers` binding.

## Verification

From the built activation script, not by reading the Nix:

```
PROJECT_DIR="/home/rounak/personal"
PROJECT_DIR="/home/rounak/work"
PROJECT_DIR="/home/rounak/work/byoc"

work      -> lyric-prototype, notprod-grafana-lyric, notprod-lyric-deploy, prod-grafana-lyric
work/byoc -> lyric-prototype, notprod-grafana-lyric, notprod-lyric-deploy, prod-grafana-lyric

linked-cases: {"byoc":…,"personal":…,"work":…}
```