### PR TITLE
Declare Codeman's permission mode, so bypass survives a redeploy

### DIFF
--- a/configs/claude/default.nix
+++ b/configs/claude/default.nix
@@ -289,6 +289,39 @@ let
   # Every lifecycle event runs the same tracker command.
   trackerHook = [{ type = "command"; command = sessionTrackerCmd; }];
 
+  # --- Permission mode: one decision, two vocabularies ---
+  # Claude runs two ways on festie, and each reads a DIFFERENT file under a
+  # DIFFERENT key name for the same concept:
+  #
+  #   bare `claude` (Tailscale SSH, cron)  ~/.claude/settings.json   permissions.defaultMode
+  #   every Codeman session (the web UI)   ~/.codeman/settings.json  claudeMode
+  #
+  # Codeman turns its key into an explicit CLI flag at spawn, and a command-line
+  # argument outranks a user settings file — so for anything launched from the web
+  # UI, which on festie is everything, Codeman's key WINS and the key below is
+  # dead weight. Setting only one of them is precisely how this drifted: #92 moved
+  # this file to "auto" for good reasons, Codeman's own dropdown was later set to
+  # "auto" by hand, and nothing in any repo recorded either half of that.
+  #
+  # So it is derived, not restated. configs/codeman owns the decision (it is that
+  # tool's config, in that tool's vocabulary); this table only translates the
+  # spelling. Hosts without Codeman — trueswiftie, ninezeroes — are NOT disposable
+  # containers and keep the classifier-guarded mode regardless.
+  codemanToClaudeMode = {
+    "dangerously-skip-permissions" = "bypassPermissions";
+    "auto" = "auto";
+    # Codeman passes no flag for either of these, so Claude Code falls through to
+    # this file; "default" (Manual) is the honest equivalent. allowedTools adds an
+    # --allowedTools list on top, which has no defaultMode spelling at all.
+    "normal" = "default";
+    "allowedTools" = "default";
+  };
+  codemanPermissionMode = config.programs.codeman.claudePermissionMode;
+  permissionDefaultMode =
+    if config.programs.codeman.enable && codemanPermissionMode != null
+    then codemanToClaudeMode.${codemanPermissionMode}
+    else "auto";
+
   # Claude Code settings as a Nix attrset for better maintainability
   claudeSettings = {
     autoUpdaterStatus = "disabled";
@@ -300,25 +333,32 @@ let
     # is named "grafana" anymore — they're notprod/prod-grafana-lyric now).
     enableAllProjectMcpServers = true;
 
-    # Auto mode: act without per-action prompts, but run each action past a
-    # classifier informed by the autoMode block below. Strictly more careful
-    # than the bypassPermissions this replaced — bypass runs everything
-    # silently, auto still refuses the things hard_deny names — and it is what
-    # the machine was being nudged towards on every new session anyway.
+    # Derived from configs/codeman — see the table above for why this is not a
+    # literal, and why it governs only a BARE `claude` (Tailscale SSH, cron, a
+    # shell in the pod) rather than the sessions you actually work in.
     #
-    # Declared here rather than left to `/auto-mode-setup` because that wizard
-    # saves its result into ~/.claude/settings.json, and on festie that path is
-    # a read-only symlink into the Nix store. The scan ran, drafted a proposal,
-    # failed to write, and re-offered itself on the next session — every deploy,
-    # forever. Configuration that a tool cannot persist has to come from here.
-    permissions.defaultMode = "auto";
+    # Derived rather than left to `/auto-mode-setup` for the original reason too:
+    # that wizard saves its result into ~/.claude/settings.json, and on festie
+    # that path is a read-only symlink into the Nix store. The scan ran, drafted
+    # a proposal, failed to write, and re-offered itself on the next session —
+    # every deploy, forever. Configuration that a tool cannot persist has to come
+    # from here.
+    permissions.defaultMode = permissionDefaultMode;
 
     # Suppress the one-time "bypass permissions mode, do you accept?" startup
-    # warning. NOTE: not in the documented settings.json reference, so it may
-    # be a no-op on current Claude Code (the documented equivalent is the
-    # --dangerously-skip-permissions CLI flag). Kept to mirror upstream intent.
+    # prompt, which would otherwise block an unattended session on a fresh
+    # volume. NOTE: not in the documented settings.json reference, so it may be
+    # a no-op on current Claude Code; the documented path is the
+    # --dangerously-skip-permissions CLI flag, which is exactly what Codeman
+    # passes. Load-bearing only for the bare-`claude` case, and only on a host
+    # where the mode above resolves to bypassPermissions.
     skipDangerousModePermissionPrompt = true;
 
+    # Read only while the mode above resolves to `auto`, and kept regardless: it
+    # is the expensive-to-rebuild half of this file, and leaving it in place makes
+    # going back to the classifier a one-word change in hosts/festie rather than
+    # an archaeology exercise. Inert, not stale.
+    #
     # Only `environment` is set. allow / soft_deny / hard_deny fall back to the
     # shipped defaults per-key (17 / 66 / 1 rules — see `claude auto-mode
     # defaults`), and those are a better-maintained baseline than anything

--- a/configs/codeman/default.nix
+++ b/configs/codeman/default.nix
@@ -1,6 +1,7 @@
 { config, lib, pkgs, ... }:
 
-# Codeman's case registry, declared rather than clicked.
+# Codeman's runtime state, declared rather than clicked: which working
+# directories it offers, and which permission mode it launches Claude in.
 #
 # A "case" is just a named working directory Codeman remembers. Cases created
 # through the UI live under ~/codeman-cases/<name>, but Codeman can also point a
@@ -13,11 +14,27 @@
 # rebuilt somewhere else, with no trace in any repo explaining what used to be
 # there. Declaring the links here is what makes the working directories a
 # property of the configuration instead of a property of one volume.
+#
+# ~/.codeman/settings.json is the same kind of state, and `claudeMode` inside it
+# is the single most consequential key on the machine: it decides the permission
+# mode of EVERY Claude session started from the web UI, which on festie is all of
+# them. Codeman turns it into an explicit CLI flag at spawn time
+# (`--dangerously-skip-permissions` or `--permission-mode auto`, see its
+# session-cli-builder), and a command-line argument outranks a settings file — so
+# this key beats ~/.claude/settings.json's permissions.defaultMode and there is
+# no way to see that from the Claude side. It had been set to "auto" from the
+# Startup Mode dropdown, a change no repo records and no Claude setting reveals,
+# so the machine ran classifier-guarded while the only permission setting anyone
+# thought to check said nothing about it either way.
+#
+# Codeman exposes NO environment variable for it (there is no CODEMAN_* var for
+# any settings key), so writing the file is the only way to declare it.
 
 let
   cfg = config.programs.codeman;
   dataDir = "${config.home.homeDirectory}/.codeman";
   linkedCasesFile = "${dataDir}/linked-cases.json";
+  settingsFile = "${dataDir}/settings.json";
 in
 {
   options.programs.codeman = {
@@ -39,38 +56,119 @@ in
         Each path is created if missing, mirroring what the link API requires.
       '';
     };
+
+    claudePermissionMode = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum [
+        "dangerously-skip-permissions"
+        "auto"
+        "normal"
+        "allowedTools"
+      ]);
+      default = null;
+      example = "dangerously-skip-permissions";
+      description = ''
+        Value for `claudeMode` in ~/.codeman/settings.json — the permission mode
+        Codeman launches every Claude session with. `null` leaves the key alone,
+        which means whatever the UI last wrote, falling back to Codeman's own
+        default of `dangerously-skip-permissions` when the key is absent.
+
+        Names match Codeman's own vocabulary rather than Claude Code's, because
+        this value is written verbatim into Codeman's config. The translation to
+        Claude Code's `permissions.defaultMode` spelling lives in configs/claude,
+        which derives its value from this one so the two cannot disagree.
+
+        `dangerously-skip-permissions` runs every tool call with no prompt and no
+        classifier. Only reasonable on a disposable machine: the Claude Code docs
+        are explicit that bypass also skips the protected-path guards on `.git`
+        and `.claude`. festie is a container behind Tinyauth, which is the whole
+        argument for it — do not carry this to a laptop.
+      '';
+    };
   };
 
-  config = lib.mkIf (cfg.enable && cfg.linkedCases != { }) {
-    home.activation.codemanLinkedCases = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      (
-        JQ_BIN="${pkgs.jq}/bin/jq"
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    (lib.mkIf (cfg.linkedCases != { }) {
+      home.activation.codemanLinkedCases = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        (
+          JQ_BIN="${pkgs.jq}/bin/jq"
 
-        mkdir -p "${dataDir}"
+          mkdir -p "${dataDir}"
 
-        # Each declared path has to exist before Codeman will resolve a case to
-        # it; the link API rejects a missing folder outright. Creating them here
-        # keeps this module self-contained rather than depending on whichever
-        # other activation step happens to run first.
-        ${lib.concatMapStringsSep "\n        " (name: ''
-        mkdir -p "${cfg.linkedCases.${name}}"
-        '') (builtins.attrNames cfg.linkedCases)}
+          # Each declared path has to exist before Codeman will resolve a case to
+          # it; the link API rejects a missing folder outright. Creating them here
+          # keeps this module self-contained rather than depending on whichever
+          # other activation step happens to run first.
+          ${lib.concatMapStringsSep "\n        " (name: ''
+          mkdir -p "${cfg.linkedCases.${name}}"
+          '') (builtins.attrNames cfg.linkedCases)}
 
-        # Merge, never clobber. Codeman owns this file at runtime, so anything
-        # linked from the UI has to survive an activation — only the declared
-        # names are asserted. Same shape as configs/claude's
-        # mergeGlobalMcpServers, including the tolerance for a corrupt file:
-        # a registry we cannot parse is replaced rather than allowed to wedge
-        # every case on the machine.
-        if [ -f "${linkedCasesFile}" ] && "$JQ_BIN" -e . "${linkedCasesFile}" >/dev/null 2>&1; then
-          "$JQ_BIN" --argjson declared '${builtins.toJSON cfg.linkedCases}' \
-            '. * $declared' "${linkedCasesFile}" > "${linkedCasesFile}.tmp" \
-            && mv "${linkedCasesFile}.tmp" "${linkedCasesFile}"
-        else
-          printf '%s\n' '${builtins.toJSON cfg.linkedCases}' \
-            | "$JQ_BIN" '.' > "${linkedCasesFile}"
-        fi
-      ) || true
-    '';
-  };
+          # Merge, never clobber. Codeman owns this file at runtime, so anything
+          # linked from the UI has to survive an activation — only the declared
+          # names are asserted. Same shape as configs/claude's
+          # mergeGlobalMcpServers, including the tolerance for a corrupt file:
+          # a registry we cannot parse is replaced rather than allowed to wedge
+          # every case on the machine.
+          if [ -f "${linkedCasesFile}" ] && "$JQ_BIN" -e . "${linkedCasesFile}" >/dev/null 2>&1; then
+            "$JQ_BIN" --argjson declared '${builtins.toJSON cfg.linkedCases}' \
+              '. * $declared' "${linkedCasesFile}" > "${linkedCasesFile}.tmp" \
+              && mv "${linkedCasesFile}.tmp" "${linkedCasesFile}"
+          else
+            printf '%s\n' '${builtins.toJSON cfg.linkedCases}' \
+              | "$JQ_BIN" '.' > "${linkedCasesFile}"
+          fi
+        ) || true
+      '';
+    })
+
+    (lib.mkIf (cfg.claudePermissionMode != null) {
+      home.activation.codemanClaudePermissionMode = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        (
+          JQ_BIN="${pkgs.jq}/bin/jq"
+
+          mkdir -p "${dataDir}"
+
+          # NOT home.file: Codeman's PUT /api/settings does a read-modify-write
+          # with fs.writeFile on this exact path, and writeFile follows a symlink
+          # to its target — so a store symlink would make every settings save in
+          # the UI fail with EROFS. That is the same trap #92 hit from the other
+          # side, where /auto-mode-setup could not persist into a nix-managed
+          # ~/.claude/settings.json and re-offered itself on every single boot.
+          #
+          # Set on EVERY activation, deliberately. The Startup Mode dropdown
+          # writes this same key, so a hand-toggle is a runtime experiment that
+          # gets reconciled back to this file on the next deploy. That is the
+          # point: the drift this fixes was one dropdown nobody could trace.
+          #
+          # Ordering is safe on the path that matters: agentfest's entrypoint runs
+          # home-manager activation (step 2) well before it execs `codeman web`
+          # (step 5), so on a boot or a fresh PVC nothing is reading or writing
+          # this file while we replace it. Running `home-manager switch` by hand
+          # against a LIVE Codeman races its own read-modify-write of the same
+          # file; the loser is one settings save, and Codeman re-reads within its
+          # 2s cache window, so this is noted rather than locked against.
+          if [ ! -s "${settingsFile}" ]; then
+            # Fresh PVC: Codeman has never written its settings. A file holding
+            # only this key is fine — Codeman merges the rest in on first save,
+            # and every other setting it reads has a documented default.
+            printf '%s\n' '${builtins.toJSON { claudeMode = cfg.claudePermissionMode; }}' \
+              | "$JQ_BIN" '.' > "${settingsFile}"
+          elif "$JQ_BIN" -e . "${settingsFile}" >/dev/null 2>&1; then
+            "$JQ_BIN" --arg mode '${cfg.claudePermissionMode}' '.claudeMode = $mode' \
+              "${settingsFile}" > "${settingsFile}.tmp" \
+              && mv "${settingsFile}.tmp" "${settingsFile}"
+          else
+            # Unlike linked-cases.json above, do NOT replace an unparseable file.
+            # This one carries notification, voice and UI state that is tedious to
+            # rebuild by hand, and a parse error is far more likely to be a
+            # half-finished write than genuine corruption. Warn and leave it:
+            # Codeman reads an unparseable settings.json as {} and falls back to
+            # its own bypass default, so the mode still lands where we wanted --
+            # but by accident, so say so rather than let it pass silently.
+            rm -f "${settingsFile}.tmp"
+            echo "WARNING: ${settingsFile} is not valid JSON; claudeMode left unset" >&2
+          fi
+        ) || true
+      '';
+    })
+  ]);
 }

--- a/configs/festie-doctor/default.nix
+++ b/configs/festie-doctor/default.nix
@@ -109,7 +109,7 @@ let
     # Declared rather than left to the inherited PATH: this runs on a machine
     # whose whole failure mode is an environment that did not come up the way it
     # should have, so it must not depend on one.
-    runtimeInputs = with pkgs; [ coreutils findutils gnugrep git gnupg ncurses openssh ];
+    runtimeInputs = with pkgs; [ coreutils findutils gnugrep git gnupg jq ncurses openssh ];
     text = ''
       fails=0
       pass() { printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
@@ -199,11 +199,54 @@ let
       # broken machine - on a machine that was fine. A checker that pins a value
       # it does not own becomes a liar at the first intentional change, and the
       # symlink section above already proves this file is the nix-managed one.
-      mode="$(sed -n 's/.*"defaultMode":"\([a-zA-Z]*\)".*/\1/p' "$HOME/.claude/settings.json" 2>/dev/null | head -1)"
-      if [ -n "$mode" ]; then
-        pass "claude permission mode: $mode"
-      else
+      #
+      # What it CAN assert is that the two halves of the decision agree, because
+      # there are two files, two vocabularies and one concept:
+      #
+      #   ~/.claude/settings.json   permissions.defaultMode   a bare 'claude'
+      #   ~/.codeman/settings.json  claudeMode                every Codeman session
+      #
+      # Codeman wins wherever they differ - it turns its key into an explicit CLI
+      # flag at spawn, and a command-line argument outranks a settings file - so a
+      # disagreement means the mode you read in one file is NOT the mode the
+      # machine runs, with nothing on the Claude side able to show it.
+      #
+      # This is also the ONLY coverage ~/.codeman/settings.json gets. It cannot be
+      # a home.file (Codeman rewrites it at runtime, see configs/codeman), so the
+      # managed-files section above cannot vouch for it. An activation that dies
+      # before codemanClaudePermissionMode leaves Codeman on its old mode while
+      # .claude/settings.json already carries the new one - which is a mismatch,
+      # and therefore caught here.
+      #
+      # Still no pinned policy: the case statement below is a mapping between two
+      # tools' names for the same mode, which stays true whichever mode is chosen.
+      # Only a MISMATCH fails.
+      mode="$(jq -r '.permissions.defaultMode // empty' "$HOME/.claude/settings.json" 2>/dev/null || true)"
+      codeman_mode="$(jq -r '.claudeMode // empty' "$HOME/.codeman/settings.json" 2>/dev/null || true)"
+      case "$codeman_mode" in
+        dangerously-skip-permissions) codeman_as_claude="bypassPermissions" ;;
+        auto)                         codeman_as_claude="auto" ;;
+        normal | allowedTools)        codeman_as_claude="default" ;;
+        *)                            codeman_as_claude="$codeman_mode" ;;
+      esac
+
+      if [ -z "$mode" ]; then
         fail "claude settings.json has no permissions.defaultMode - missing, or not the nix-managed one"
+      elif [ -z "$codeman_mode" ]; then
+        # Absent is not neutral. Codeman falls back to its OWN default,
+        # dangerously-skip-permissions, whenever the key is missing or the file
+        # cannot be parsed - so this reads as "no opinion" while granting the most
+        # permissive mode there is.
+        fail "codeman settings.json has no claudeMode - Codeman falls back to bypass"
+        note "activation should have written it; see configs/codeman"
+        note "bare claude is on: $mode"
+      elif [ "$mode" = "$codeman_as_claude" ]; then
+        pass "claude permission mode: $mode (both layers agree)"
+      else
+        fail "permission mode disagrees between layers, and Codeman is the one that wins"
+        note "bare claude   ~/.claude/settings.json   $mode"
+        note "codeman       ~/.codeman/settings.json  $codeman_mode (= $codeman_as_claude)"
+        note "every session you start from the UI runs the codeman one"
       fi
       if grep -q "pinentry" "$HOME/.gnupg/gpg-agent.conf" 2>/dev/null; then
         pass "gpg-agent has a pinentry-program"

--- a/hosts/festie/home.nix
+++ b/hosts/festie/home.nix
@@ -181,6 +181,26 @@
     # PVC, so a link made by hand does not survive being deployed elsewhere.
     codeman = {
       enable = true;
+
+      # The permission mode for every session started from the Codeman UI, and
+      # (translated by configs/claude) for a bare `claude` too. This is THE knob:
+      # Codeman passes it as a CLI flag, which outranks ~/.claude/settings.json,
+      # so nothing on the Claude side can override or reveal it.
+      #
+      # Bypass because the entire point of this machine is work that finishes
+      # while nobody is watching it, and a prompt waiting for an answer is the one
+      # failure mode that costs the whole session. Defensible only because festie
+      # is disposable: a container, one PVC, rebuilt from this repo, with Velero
+      # backups behind it. It is NOT defensible on a laptop, and no other host
+      # enables this module, so no other host gets it.
+      #
+      # The cost is real and worth naming: bypass also skips the protected-path
+      # guards on .git and .claude, and the ingress in front of this pod resolves
+      # to a public IP with Tinyauth as the only layer. A Tinyauth bypass now
+      # yields an unprompted shell with a GPG key and cluster credentials, not a
+      # classifier-guarded agent. Set to "auto" to trade latency for that margin.
+      claudePermissionMode = "dangerously-skip-permissions";
+
       linkedCases = {
         personal = "${config.home.homeDirectory}/personal";
         work = "${config.home.homeDirectory}/work";


### PR DESCRIPTION
festie's permission mode lived in Codeman's Startup Mode dropdown — a place no repo records and no Claude setting reveals. #92 moved `permissions.defaultMode` to `auto`; Codeman's own `claudeMode` was separately set to `auto` from the UI. Reading `~/.claude/settings.json`, the only permission setting anybody thinks to check, told you nothing about what sessions actually ran.

Codeman wins that contest. It turns `claudeMode` into an explicit CLI flag at spawn (`--dangerously-skip-permissions` / `--permission-mode auto`), and a command-line argument outranks a user settings file. All nine of its spawn paths read the same global key, so there is exactly one knob — and it was the undeclared one. There is no `CODEMAN_*` env var for any settings key, so writing the file is the only way to declare it.

## Changes

- **`hosts/festie/home.nix`** — the decision, one line: `claudePermissionMode = "dangerously-skip-permissions"`, with the reasoning for why it is defensible on a disposable container and nowhere else.
- **`configs/codeman`** — new `programs.codeman.claudePermissionMode` option and an activation step that jq-merges the key. Not `home.file`: Codeman's `PUT /api/settings` does a read-modify-`fs.writeFile` on that path and `writeFile` follows symlinks, so a store symlink would make every settings save in the UI fail with EROFS — the same trap #92 hit from the other side. Declines to replace a file it cannot parse rather than costing you the notification, voice and UI state.
- **`configs/claude`** — `permissions.defaultMode` is now *derived* from that option through a vocabulary table instead of restating the decision, so the two files cannot disagree again.
- **`configs/festie-doctor`** — reports both halves and fails when they disagree. Still pins no policy: the case statement maps two tools' names for the same mode, true whichever mode is chosen. This is the only coverage `~/.codeman/settings.json` gets — it cannot be a managed file, so an activation that dies before the new step surfaces here as a mismatch. `jq` joins `runtimeInputs`; the old check parsed with a `sed` regex against a binary not in its closure.

## Blast radius

Only festie enables the codeman module, which is what scopes this. `ninezeroes` and `trueswiftie` still evaluate to `auto` — bypass does not reach a laptop.

## Verification

`nixpkgs-fmt --check .` and all three eval checks pass locally. festie renders `defaultMode=bypassPermissions` plus an activation step carrying `dangerously-skip-permissions`; the other two hosts render `auto`.

Activation logic exercised against five fixtures: a real 43-key `settings.json` (mode flipped, all keys and nested state intact), missing file, empty file, corrupt file (untouched, warned, no stray `.tmp`), and a second run (byte-identical). Doctor check exercised against six, including the disagreement case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
